### PR TITLE
Add exec shell, GitHub CLI, and git repo utilities

### DIFF
--- a/internal/execshell/doc.go
+++ b/internal/execshell/doc.go
@@ -1,0 +1,3 @@
+// Package execshell provides structured helpers for invoking external command line tools
+// such as git, gh, and curl while capturing output details and emitting structured logs.
+package execshell

--- a/internal/execshell/executor.go
+++ b/internal/execshell/executor.go
@@ -1,0 +1,173 @@
+package execshell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.uber.org/zap"
+)
+
+const (
+	gitCommandNameStringConstant              = "git"
+	githubCLICommandNameStringConstant        = "gh"
+	curlCommandNameStringConstant             = "curl"
+	loggerNotConfiguredMessageConstant        = "shell executor logger not configured"
+	commandRunnerNotConfiguredMessageConstant = "shell executor command runner not configured"
+	commandNameMissingMessageConstant         = "shell command name not provided"
+	commandStartMessageConstant               = "starting external command"
+	commandSuccessMessageConstant             = "external command completed"
+	commandFailureMessageConstant             = "external command reported failure"
+	commandRunnerErrorMessageConstant         = "external command execution error"
+	commandNameFieldNameConstant              = "command"
+	commandArgumentsFieldNameConstant         = "arguments"
+	workingDirectoryFieldNameConstant         = "working_directory"
+	exitCodeFieldNameConstant                 = "exit_code"
+	standardErrorFieldNameConstant            = "stderr"
+)
+
+// CommandName identifies a supported executable name.
+type CommandName string
+
+// Supported command names.
+const (
+	CommandGit    CommandName = CommandName(gitCommandNameStringConstant)
+	CommandGitHub CommandName = CommandName(githubCLICommandNameStringConstant)
+	CommandCurl   CommandName = CommandName(curlCommandNameStringConstant)
+)
+
+// CommandDetails describes command invocation properties.
+type CommandDetails struct {
+	Arguments            []string
+	WorkingDirectory     string
+	EnvironmentVariables map[string]string
+	StandardInput        []byte
+}
+
+// ShellCommand represents a fully qualified command invocation.
+type ShellCommand struct {
+	Name    CommandName
+	Details CommandDetails
+}
+
+// ExecutionResult captures observable command results.
+type ExecutionResult struct {
+	StandardOutput string
+	StandardError  string
+	ExitCode       int
+}
+
+// CommandRunner executes shell commands.
+type CommandRunner interface {
+	Run(executionContext context.Context, command ShellCommand) (ExecutionResult, error)
+}
+
+// ShellExecutor orchestrates running shell commands with logging.
+type ShellExecutor struct {
+	commandRunner CommandRunner
+	logger        *zap.Logger
+}
+
+var (
+	// ErrLoggerNotConfigured indicates the logger dependency was missing.
+	ErrLoggerNotConfigured = errors.New(loggerNotConfiguredMessageConstant)
+	// ErrCommandRunnerNotConfigured indicates the command runner dependency was missing.
+	ErrCommandRunnerNotConfigured = errors.New(commandRunnerNotConfiguredMessageConstant)
+	// ErrCommandNameMissing indicates the command name was not provided.
+	ErrCommandNameMissing = errors.New(commandNameMissingMessageConstant)
+)
+
+// CommandFailedError provides details about commands exiting with a non-zero code.
+type CommandFailedError struct {
+	Command ShellCommand
+	Result  ExecutionResult
+}
+
+const commandFailureErrorMessageTemplateConstant = "%s command exited with code %d"
+
+// Error describes the failure in a readable format.
+func (commandError CommandFailedError) Error() string {
+	return fmt.Sprintf(commandFailureErrorMessageTemplateConstant, commandError.Command.Name, commandError.Result.ExitCode)
+}
+
+// CommandExecutionError wraps unexpected execution failures from the runner.
+type CommandExecutionError struct {
+	Command ShellCommand
+	Cause   error
+}
+
+const commandExecutionErrorMessageTemplateConstant = "%s command execution failed"
+
+// Error describes the underlying runner failure.
+func (executionError CommandExecutionError) Error() string {
+	return fmt.Sprintf(commandExecutionErrorMessageTemplateConstant, executionError.Command.Name)
+}
+
+// Unwrap exposes the underlying error.
+func (executionError CommandExecutionError) Unwrap() error {
+	return executionError.Cause
+}
+
+// NewShellExecutor builds an executor for the provided runner and logger.
+func NewShellExecutor(logger *zap.Logger, commandRunner CommandRunner) (*ShellExecutor, error) {
+	if logger == nil {
+		return nil, ErrLoggerNotConfigured
+	}
+	if commandRunner == nil {
+		return nil, ErrCommandRunnerNotConfigured
+	}
+
+	return &ShellExecutor{commandRunner: commandRunner, logger: logger}, nil
+}
+
+// Execute runs the provided shell command and logs lifecycle events.
+func (executor *ShellExecutor) Execute(executionContext context.Context, command ShellCommand) (ExecutionResult, error) {
+	if len(command.Name) == 0 {
+		return ExecutionResult{}, ErrCommandNameMissing
+	}
+
+	executor.logger.Info(commandStartMessageConstant,
+		zap.String(commandNameFieldNameConstant, string(command.Name)),
+		zap.Strings(commandArgumentsFieldNameConstant, command.Details.Arguments),
+		zap.String(workingDirectoryFieldNameConstant, command.Details.WorkingDirectory),
+	)
+
+	executionResult, runnerError := executor.commandRunner.Run(executionContext, command)
+	if runnerError != nil {
+		executor.logger.Error(commandRunnerErrorMessageConstant,
+			zap.String(commandNameFieldNameConstant, string(command.Name)),
+			zap.Error(runnerError),
+		)
+		return ExecutionResult{}, CommandExecutionError{Command: command, Cause: runnerError}
+	}
+
+	if executionResult.ExitCode != 0 {
+		executor.logger.Warn(commandFailureMessageConstant,
+			zap.String(commandNameFieldNameConstant, string(command.Name)),
+			zap.Int(exitCodeFieldNameConstant, executionResult.ExitCode),
+			zap.String(standardErrorFieldNameConstant, executionResult.StandardError),
+		)
+		return ExecutionResult{}, CommandFailedError{Command: command, Result: executionResult}
+	}
+
+	executor.logger.Info(commandSuccessMessageConstant,
+		zap.String(commandNameFieldNameConstant, string(command.Name)),
+		zap.Int(exitCodeFieldNameConstant, executionResult.ExitCode),
+	)
+	return executionResult, nil
+}
+
+// ExecuteGit runs the git executable with the provided details.
+func (executor *ShellExecutor) ExecuteGit(executionContext context.Context, details CommandDetails) (ExecutionResult, error) {
+	return executor.Execute(executionContext, ShellCommand{Name: CommandGit, Details: details})
+}
+
+// ExecuteGitHubCLI runs the GitHub CLI executable with the provided details.
+func (executor *ShellExecutor) ExecuteGitHubCLI(executionContext context.Context, details CommandDetails) (ExecutionResult, error) {
+	return executor.Execute(executionContext, ShellCommand{Name: CommandGitHub, Details: details})
+}
+
+// ExecuteCurl runs the curl executable with the provided details.
+func (executor *ShellExecutor) ExecuteCurl(executionContext context.Context, details CommandDetails) (ExecutionResult, error) {
+	return executor.Execute(executionContext, ShellCommand{Name: CommandCurl, Details: details})
+}

--- a/internal/execshell/executor_test.go
+++ b/internal/execshell/executor_test.go
@@ -1,0 +1,197 @@
+package execshell_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	testExecutionSuccessCaseNameConstant         = "success"
+	testExecutionFailureCaseNameConstant         = "failure_exit_code"
+	testExecutionRunnerErrorCaseNameConstant     = "runner_error"
+	testGitWrapperCaseNameConstant               = "git_wrapper"
+	testGitHubWrapperCaseNameConstant            = "github_wrapper"
+	testCurlWrapperCaseNameConstant              = "curl_wrapper"
+	testCommandArgumentConstant                  = "--version"
+	testWorkingDirectoryConstant                 = "."
+	testStandardErrorOutputConstant              = "failure"
+	testLoggerInitializationCaseNameConstant     = "logger_validation"
+	testRunnerInitializationCaseNameConstant     = "runner_validation"
+	testSuccessfulInitializationCaseNameConstant = "successful_initialization"
+)
+
+type recordingCommandRunner struct {
+	executionResult  execshell.ExecutionResult
+	executionError   error
+	recordedCommands []execshell.ShellCommand
+}
+
+func (runner *recordingCommandRunner) Run(executionContext context.Context, command execshell.ShellCommand) (execshell.ExecutionResult, error) {
+	runner.recordedCommands = append(runner.recordedCommands, command)
+	return runner.executionResult, runner.executionError
+}
+
+func TestShellExecutorInitializationValidation(testInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		logger        *zap.Logger
+		runner        execshell.CommandRunner
+		expectError   error
+		expectSuccess bool
+	}{
+		{
+			name:        testLoggerInitializationCaseNameConstant,
+			logger:      nil,
+			runner:      &recordingCommandRunner{},
+			expectError: execshell.ErrLoggerNotConfigured,
+		},
+		{
+			name:        testRunnerInitializationCaseNameConstant,
+			logger:      zap.NewNop(),
+			runner:      nil,
+			expectError: execshell.ErrCommandRunnerNotConfigured,
+		},
+		{
+			name:          testSuccessfulInitializationCaseNameConstant,
+			logger:        zap.NewNop(),
+			runner:        &recordingCommandRunner{},
+			expectSuccess: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			executor, creationError := execshell.NewShellExecutor(testCase.logger, testCase.runner)
+			if testCase.expectSuccess {
+				require.NoError(testInstance, creationError)
+				require.NotNil(testInstance, executor)
+			} else {
+				require.Error(testInstance, creationError)
+				require.ErrorIs(testInstance, creationError, testCase.expectError)
+			}
+		})
+	}
+}
+
+func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
+	testCases := []struct {
+		name             string
+		runnerResult     execshell.ExecutionResult
+		runnerError      error
+		expectErrorType  any
+		expectedLogCount int
+	}{
+		{
+			name: testExecutionSuccessCaseNameConstant,
+			runnerResult: execshell.ExecutionResult{
+				StandardOutput: "ok",
+				ExitCode:       0,
+			},
+			expectedLogCount: 2,
+		},
+		{
+			name: testExecutionFailureCaseNameConstant,
+			runnerResult: execshell.ExecutionResult{
+				StandardError: testStandardErrorOutputConstant,
+				ExitCode:      1,
+			},
+			expectErrorType:  execshell.CommandFailedError{},
+			expectedLogCount: 2,
+		},
+		{
+			name:             testExecutionRunnerErrorCaseNameConstant,
+			runnerError:      errors.New("runner failure"),
+			expectErrorType:  execshell.CommandExecutionError{},
+			expectedLogCount: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			observerCore, observerLogs := observer.New(zap.DebugLevel)
+			logger := zap.New(observerCore)
+
+			recordingRunner := &recordingCommandRunner{
+				executionResult: testCase.runnerResult,
+				executionError:  testCase.runnerError,
+			}
+
+			shellExecutor, creationError := execshell.NewShellExecutor(logger, recordingRunner)
+			require.NoError(testInstance, creationError)
+
+			commandDetails := execshell.CommandDetails{Arguments: []string{testCommandArgumentConstant}, WorkingDirectory: testWorkingDirectoryConstant}
+			executionResult, executionError := shellExecutor.ExecuteGit(context.Background(), commandDetails)
+
+			if testCase.expectErrorType != nil {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.expectErrorType, executionError)
+				require.Empty(testInstance, executionResult.StandardOutput)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.Equal(testInstance, testCase.runnerResult.StandardOutput, executionResult.StandardOutput)
+			}
+
+			require.Len(testInstance, observerLogs.All(), testCase.expectedLogCount)
+		})
+	}
+}
+
+func TestShellExecutorWrappersSetCommandNames(testInstance *testing.T) {
+	observerCore, _ := observer.New(zap.DebugLevel)
+	logger := zap.New(observerCore)
+
+	testCases := []struct {
+		name            string
+		invoke          func(executor *execshell.ShellExecutor) error
+		expectedCommand execshell.CommandName
+	}{
+		{
+			name: testGitWrapperCaseNameConstant,
+			invoke: func(executor *execshell.ShellExecutor) error {
+				_, executionError := executor.ExecuteGit(context.Background(), execshell.CommandDetails{})
+				return executionError
+			},
+			expectedCommand: execshell.CommandGit,
+		},
+		{
+			name: testGitHubWrapperCaseNameConstant,
+			invoke: func(executor *execshell.ShellExecutor) error {
+				_, executionError := executor.ExecuteGitHubCLI(context.Background(), execshell.CommandDetails{})
+				return executionError
+			},
+			expectedCommand: execshell.CommandGitHub,
+		},
+		{
+			name: testCurlWrapperCaseNameConstant,
+			invoke: func(executor *execshell.ShellExecutor) error {
+				_, executionError := executor.ExecuteCurl(context.Background(), execshell.CommandDetails{})
+				return executionError
+			},
+			expectedCommand: execshell.CommandCurl,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			recordingRunner := &recordingCommandRunner{
+				executionResult: execshell.ExecutionResult{ExitCode: 1},
+			}
+
+			executor, creationError := execshell.NewShellExecutor(logger, recordingRunner)
+			require.NoError(testInstance, creationError)
+
+			executionError := testCase.invoke(executor)
+			require.Error(testInstance, executionError)
+			require.Len(testInstance, recordingRunner.recordedCommands, 1)
+			recordedCommand := recordingRunner.recordedCommands[0]
+			require.Equal(testInstance, testCase.expectedCommand, recordedCommand.Name)
+		})
+	}
+}

--- a/internal/execshell/os_runner.go
+++ b/internal/execshell/os_runner.go
@@ -1,0 +1,69 @@
+package execshell
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const (
+	environmentAssignmentSeparatorConstant = "="
+	environmentAssignmentTemplateConstant  = "%s%s%s"
+)
+
+// OSCommandRunner executes commands using the operating system facilities.
+type OSCommandRunner struct{}
+
+// NewOSCommandRunner constructs a runner backed by os/exec.
+func NewOSCommandRunner() *OSCommandRunner {
+	return &OSCommandRunner{}
+}
+
+// Run executes the supplied command using os/exec.
+func (runner *OSCommandRunner) Run(executionContext context.Context, command ShellCommand) (ExecutionResult, error) {
+	commandArguments := append([]string{}, command.Details.Arguments...)
+	executable := exec.CommandContext(executionContext, string(command.Name), commandArguments...)
+
+	if len(command.Details.WorkingDirectory) > 0 {
+		executable.Dir = command.Details.WorkingDirectory
+	}
+
+	if len(command.Details.EnvironmentVariables) > 0 {
+		mergedEnvironment := append([]string{}, os.Environ()...)
+		for environmentKey, environmentValue := range command.Details.EnvironmentVariables {
+			mergedEnvironment = append(mergedEnvironment, fmt.Sprintf(environmentAssignmentTemplateConstant, environmentKey, environmentAssignmentSeparatorConstant, environmentValue))
+		}
+		executable.Env = mergedEnvironment
+	}
+
+	var standardOutputBuffer bytes.Buffer
+	var standardErrorBuffer bytes.Buffer
+	executable.Stdout = &standardOutputBuffer
+	executable.Stderr = &standardErrorBuffer
+
+	if len(command.Details.StandardInput) > 0 {
+		executable.Stdin = bytes.NewReader(command.Details.StandardInput)
+	}
+
+	runError := executable.Run()
+	if runError != nil {
+		exitError := &exec.ExitError{}
+		if errors.As(runError, &exitError) {
+			return ExecutionResult{
+				StandardOutput: standardOutputBuffer.String(),
+				StandardError:  standardErrorBuffer.String(),
+				ExitCode:       exitError.ExitCode(),
+			}, nil
+		}
+		return ExecutionResult{}, runError
+	}
+
+	return ExecutionResult{
+		StandardOutput: standardOutputBuffer.String(),
+		StandardError:  standardErrorBuffer.String(),
+		ExitCode:       0,
+	}, nil
+}

--- a/internal/githubcli/client.go
+++ b/internal/githubcli/client.go
@@ -1,0 +1,330 @@
+package githubcli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	repoSubcommandConstant                  = "repo"
+	viewSubcommandConstant                  = "view"
+	pullRequestSubcommandConstant           = "pr"
+	listSubcommandConstant                  = "list"
+	apiSubcommandConstant                   = "api"
+	jsonFlagConstant                        = "--json"
+	repoFlagConstant                        = "--repo"
+	stateFlagConstant                       = "--state"
+	baseFlagConstant                        = "--base"
+	limitFlagConstant                       = "--limit"
+	methodFlagConstant                      = "-X"
+	inputFlagConstant                       = "--input"
+	stdinReferenceConstant                  = "-"
+	acceptHeaderFlagConstant                = "-H"
+	acceptHeaderValueConstant               = "Accept: application/vnd.github+json"
+	repositoryFieldNameConstant             = "repository"
+	baseBranchFieldNameConstant             = "base_branch"
+	sourceBranchFieldNameConstant           = "source_branch"
+	stateFieldNameConstant                  = "state"
+	requiredValueMessageConstant            = "value required"
+	executorNotConfiguredMessageConstant    = "github cli executor not configured"
+	pullRequestLimitDefaultValueConstant    = 100
+	pullRequestJSONFieldsConstant           = "number,title,headRefName"
+	repoViewJSONFieldsConstant              = "defaultBranchRef,nameWithOwner,description"
+	operationErrorMessageTemplateConstant   = "%s operation failed"
+	operationErrorWithCauseTemplateConstant = "%s operation failed: %s"
+	responseDecodingErrorTemplateConstant   = "%s response decoding failed: %s"
+	payloadEncodingErrorTemplateConstant    = "%s payload encoding failed: %s"
+	invalidInputErrorTemplateConstant       = "%s: %s"
+	pagesEndpointTemplateConstant           = "repos/%s/pages"
+	repositoryMetadataOperationNameConstant = OperationName("ResolveRepoMetadata")
+	listPullRequestsOperationNameConstant   = OperationName("ListPullRequests")
+	updatePagesOperationNameConstant        = OperationName("UpdatePagesConfig")
+)
+
+// OperationName describes a named GitHub CLI workflow supported by the client.
+type OperationName string
+
+// PullRequestState describes acceptable GitHub pull request states.
+type PullRequestState string
+
+// Pull request state enumerations.
+const (
+	PullRequestStateOpen   PullRequestState = PullRequestState("open")
+	PullRequestStateClosed PullRequestState = PullRequestState("closed")
+	PullRequestStateMerged PullRequestState = PullRequestState("merged")
+)
+
+// RepositoryMetadata contains key details resolved from GitHub.
+type RepositoryMetadata struct {
+	NameWithOwner string
+	Description   string
+	DefaultBranch string
+}
+
+// PullRequest represents minimal PR details returned by GitHub CLI.
+type PullRequest struct {
+	Number      int
+	Title       string
+	HeadRefName string
+}
+
+// PullRequestListOptions configures ListPullRequests queries.
+type PullRequestListOptions struct {
+	State       PullRequestState
+	BaseBranch  string
+	ResultLimit int
+}
+
+// PagesConfiguration describes the desired GitHub Pages configuration.
+type PagesConfiguration struct {
+	SourceBranch string
+	SourcePath   string
+}
+
+// GitHubCommandExecutor is the minimal interface required from execshell.ShellExecutor.
+type GitHubCommandExecutor interface {
+	ExecuteGitHubCLI(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error)
+}
+
+// Client coordinates GitHub CLI invocations through execshell.
+type Client struct {
+	executor GitHubCommandExecutor
+}
+
+var (
+	// ErrExecutorNotConfigured indicates the client was constructed without an executor.
+	ErrExecutorNotConfigured = errors.New(executorNotConfiguredMessageConstant)
+)
+
+// InvalidInputError surfaces validation issues for operation inputs.
+type InvalidInputError struct {
+	FieldName string
+	Message   string
+}
+
+// Error describes the invalid input.
+func (inputError InvalidInputError) Error() string {
+	return fmt.Sprintf(invalidInputErrorTemplateConstant, inputError.FieldName, inputError.Message)
+}
+
+// OperationError wraps execution issues for GitHub CLI operations.
+type OperationError struct {
+	Operation OperationName
+	Cause     error
+}
+
+// Error describes the operation failure.
+func (operationError OperationError) Error() string {
+	if operationError.Cause == nil {
+		return fmt.Sprintf(operationErrorMessageTemplateConstant, operationError.Operation)
+	}
+	return fmt.Sprintf(operationErrorWithCauseTemplateConstant, operationError.Operation, operationError.Cause)
+}
+
+// Unwrap exposes the underlying cause.
+func (operationError OperationError) Unwrap() error {
+	return operationError.Cause
+}
+
+// ResponseDecodingError indicates JSON decoding failures.
+type ResponseDecodingError struct {
+	Operation OperationName
+	Cause     error
+}
+
+// Error describes the decoding failure.
+func (decodingError ResponseDecodingError) Error() string {
+	return fmt.Sprintf(responseDecodingErrorTemplateConstant, decodingError.Operation, decodingError.Cause)
+}
+
+// Unwrap exposes the underlying JSON error.
+func (decodingError ResponseDecodingError) Unwrap() error {
+	return decodingError.Cause
+}
+
+// PayloadEncodingError indicates JSON encoding issues.
+type PayloadEncodingError struct {
+	Operation OperationName
+	Cause     error
+}
+
+// Error describes the encoding failure.
+func (encodingError PayloadEncodingError) Error() string {
+	return fmt.Sprintf(payloadEncodingErrorTemplateConstant, encodingError.Operation, encodingError.Cause)
+}
+
+// Unwrap exposes the underlying error.
+func (encodingError PayloadEncodingError) Unwrap() error {
+	return encodingError.Cause
+}
+
+// NewClient constructs a GitHub CLI client.
+func NewClient(executor GitHubCommandExecutor) (*Client, error) {
+	if executor == nil {
+		return nil, ErrExecutorNotConfigured
+	}
+	return &Client{executor: executor}, nil
+}
+
+// ResolveRepoMetadata retrieves canonical metadata for a repository using gh repo view.
+func (client *Client) ResolveRepoMetadata(executionContext context.Context, repository string) (RepositoryMetadata, error) {
+	repositoryIdentifier := strings.TrimSpace(repository)
+	if len(repositoryIdentifier) == 0 {
+		return RepositoryMetadata{}, InvalidInputError{FieldName: repositoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			repoSubcommandConstant,
+			viewSubcommandConstant,
+			repositoryIdentifier,
+			jsonFlagConstant,
+			repoViewJSONFieldsConstant,
+		},
+	}
+
+	executionResult, executionError := client.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError != nil {
+		return RepositoryMetadata{}, OperationError{Operation: repositoryMetadataOperationNameConstant, Cause: executionError}
+	}
+
+	var response struct {
+		NameWithOwner    string `json:"nameWithOwner"`
+		Description      string `json:"description"`
+		DefaultBranchRef struct {
+			Name string `json:"name"`
+		} `json:"defaultBranchRef"`
+	}
+
+	decodingError := json.Unmarshal([]byte(executionResult.StandardOutput), &response)
+	if decodingError != nil {
+		return RepositoryMetadata{}, ResponseDecodingError{Operation: repositoryMetadataOperationNameConstant, Cause: decodingError}
+	}
+
+	return RepositoryMetadata{
+		NameWithOwner: response.NameWithOwner,
+		Description:   response.Description,
+		DefaultBranch: response.DefaultBranchRef.Name,
+	}, nil
+}
+
+// ListPullRequests enumerates pull requests using gh pr list.
+func (client *Client) ListPullRequests(executionContext context.Context, repository string, options PullRequestListOptions) ([]PullRequest, error) {
+	repositoryIdentifier := strings.TrimSpace(repository)
+	if len(repositoryIdentifier) == 0 {
+		return nil, InvalidInputError{FieldName: repositoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	if len(strings.TrimSpace(options.BaseBranch)) == 0 {
+		return nil, InvalidInputError{FieldName: baseBranchFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	if len(options.State) == 0 {
+		return nil, InvalidInputError{FieldName: stateFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	resultLimit := options.ResultLimit
+	if resultLimit <= 0 {
+		resultLimit = pullRequestLimitDefaultValueConstant
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			pullRequestSubcommandConstant,
+			listSubcommandConstant,
+			repoFlagConstant,
+			repositoryIdentifier,
+			stateFlagConstant,
+			string(options.State),
+			baseFlagConstant,
+			options.BaseBranch,
+			jsonFlagConstant,
+			pullRequestJSONFieldsConstant,
+			limitFlagConstant,
+			strconv.Itoa(resultLimit),
+		},
+	}
+
+	executionResult, executionError := client.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError != nil {
+		return nil, OperationError{Operation: listPullRequestsOperationNameConstant, Cause: executionError}
+	}
+
+	var response []struct {
+		Number      int    `json:"number"`
+		Title       string `json:"title"`
+		HeadRefName string `json:"headRefName"`
+	}
+
+	decodingError := json.Unmarshal([]byte(executionResult.StandardOutput), &response)
+	if decodingError != nil {
+		return nil, ResponseDecodingError{Operation: listPullRequestsOperationNameConstant, Cause: decodingError}
+	}
+
+	pullRequests := make([]PullRequest, 0, len(response))
+	for _, pullRequestEntry := range response {
+		pullRequests = append(pullRequests, PullRequest{
+			Number:      pullRequestEntry.Number,
+			Title:       pullRequestEntry.Title,
+			HeadRefName: pullRequestEntry.HeadRefName,
+		})
+	}
+
+	return pullRequests, nil
+}
+
+// UpdatePagesConfig updates the GitHub Pages configuration using gh api.
+func (client *Client) UpdatePagesConfig(executionContext context.Context, repository string, configuration PagesConfiguration) error {
+	repositoryIdentifier := strings.TrimSpace(repository)
+	if len(repositoryIdentifier) == 0 {
+		return InvalidInputError{FieldName: repositoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	if len(strings.TrimSpace(configuration.SourceBranch)) == 0 {
+		return InvalidInputError{FieldName: sourceBranchFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	payload := struct {
+		Source struct {
+			Branch string `json:"branch"`
+			Path   string `json:"path"`
+		} `json:"source"`
+	}{}
+
+	payload.Source.Branch = configuration.SourceBranch
+	payload.Source.Path = configuration.SourcePath
+
+	payloadBytes, encodingError := json.Marshal(payload)
+	if encodingError != nil {
+		return PayloadEncodingError{Operation: updatePagesOperationNameConstant, Cause: encodingError}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			apiSubcommandConstant,
+			fmt.Sprintf(pagesEndpointTemplateConstant, repositoryIdentifier),
+			methodFlagConstant,
+			httpMethodPutConstant,
+			inputFlagConstant,
+			stdinReferenceConstant,
+			acceptHeaderFlagConstant,
+			acceptHeaderValueConstant,
+		},
+		StandardInput: payloadBytes,
+	}
+
+	_, executionError := client.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError != nil {
+		return OperationError{Operation: updatePagesOperationNameConstant, Cause: executionError}
+	}
+
+	return nil
+}
+
+const httpMethodPutConstant = "PUT"

--- a/internal/githubcli/client_test.go
+++ b/internal/githubcli/client_test.go
@@ -1,0 +1,291 @@
+package githubcli_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
+)
+
+const (
+	testRepositoryIdentifierConstant                = "owner/example"
+	testBaseBranchConstant                          = "main"
+	testPullRequestTitleConstant                    = "Example"
+	testPullRequestHeadConstant                     = "feature/example"
+	testPagesSourceBranchConstant                   = "gh-pages"
+	testPagesSourcePathConstant                     = "/docs"
+	testResolveSuccessCaseNameConstant              = "resolve_success"
+	testResolveDecodeFailureCaseNameConstant        = "resolve_decode_failure"
+	testResolveCommandFailureCaseNameConstant       = "resolve_command_failure"
+	testResolveInputFailureCaseNameConstant         = "resolve_input_failure"
+	testListSuccessCaseNameConstant                 = "list_success"
+	testListDecodeFailureCaseNameConstant           = "list_decode_failure"
+	testListCommandFailureCaseNameConstant          = "list_command_failure"
+	testListRepositoryValidationCaseNameConstant    = "list_repository_validation"
+	testListBaseValidationCaseNameConstant          = "list_base_validation"
+	testListStateValidationCaseNameConstant         = "list_state_validation"
+	testPagesSuccessCaseNameConstant                = "pages_success"
+	testPagesCommandFailureCaseNameConstant         = "pages_command_failure"
+	testPagesRepositoryValidationCaseNameConstant   = "pages_repository_validation"
+	testPagesSourceBranchValidationCaseNameConstant = "pages_source_branch_validation"
+)
+
+type stubGitHubExecutor struct {
+	executeFunc     func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error)
+	recordedDetails []execshell.CommandDetails
+}
+
+func (executor *stubGitHubExecutor) ExecuteGitHubCLI(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	executor.recordedDetails = append(executor.recordedDetails, details)
+	if executor.executeFunc != nil {
+		return executor.executeFunc(executionContext, details)
+	}
+	return execshell.ExecutionResult{}, nil
+}
+
+func TestNewClientValidation(testInstance *testing.T) {
+	testInstance.Run("nil_executor", func(testInstance *testing.T) {
+		client, creationError := githubcli.NewClient(nil)
+		require.Error(testInstance, creationError)
+		require.ErrorIs(testInstance, creationError, githubcli.ErrExecutorNotConfigured)
+		require.Nil(testInstance, client)
+	})
+}
+
+func TestResolveRepoMetadata(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		repository  string
+		executor    *stubGitHubExecutor
+		expectError bool
+		errorType   any
+		verify      func(testInstance *testing.T, metadata githubcli.RepositoryMetadata, executor *stubGitHubExecutor)
+	}{
+		{
+			name:       testResolveSuccessCaseNameConstant,
+			repository: testRepositoryIdentifierConstant,
+			executor: &stubGitHubExecutor{
+				executeFunc: func(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+					return execshell.ExecutionResult{StandardOutput: `{"nameWithOwner":"owner/example","description":"Example repo","defaultBranchRef":{"name":"main"}}`}, nil
+				},
+			},
+			verify: func(testInstance *testing.T, metadata githubcli.RepositoryMetadata, executor *stubGitHubExecutor) {
+				require.Equal(testInstance, "owner/example", metadata.NameWithOwner)
+				require.Equal(testInstance, "Example repo", metadata.Description)
+				require.Equal(testInstance, "main", metadata.DefaultBranch)
+				require.Len(testInstance, executor.recordedDetails, 1)
+				require.Contains(testInstance, executor.recordedDetails[0].Arguments, testRepositoryIdentifierConstant)
+			},
+		},
+		{
+			name:       testResolveDecodeFailureCaseNameConstant,
+			repository: testRepositoryIdentifierConstant,
+			executor: &stubGitHubExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{StandardOutput: "not-json"}, nil
+			}},
+			expectError: true,
+			errorType:   githubcli.ResponseDecodingError{},
+		},
+		{
+			name:       testResolveCommandFailureCaseNameConstant,
+			repository: testRepositoryIdentifierConstant,
+			executor: &stubGitHubExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandFailedError{Command: execshell.ShellCommand{Name: execshell.CommandGitHub}, Result: execshell.ExecutionResult{ExitCode: 1}}
+			}},
+			expectError: true,
+			errorType:   githubcli.OperationError{},
+		},
+		{
+			name:        testResolveInputFailureCaseNameConstant,
+			repository:  "  ",
+			executor:    &stubGitHubExecutor{},
+			expectError: true,
+			errorType:   githubcli.InvalidInputError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			client, creationError := githubcli.NewClient(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			metadata, resolutionError := client.ResolveRepoMetadata(context.Background(), testCase.repository)
+			if testCase.expectError {
+				require.Error(testInstance, resolutionError)
+				require.IsType(testInstance, testCase.errorType, resolutionError)
+			} else {
+				require.NoError(testInstance, resolutionError)
+				require.NotNil(testInstance, testCase.verify)
+				testCase.verify(testInstance, metadata, testCase.executor)
+			}
+		})
+	}
+}
+
+func TestListPullRequests(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		repository  string
+		options     githubcli.PullRequestListOptions
+		executor    *stubGitHubExecutor
+		expectError bool
+		errorType   any
+		verify      func(testInstance *testing.T, pullRequests []githubcli.PullRequest, executor *stubGitHubExecutor)
+	}{
+		{
+			name:       testListSuccessCaseNameConstant,
+			repository: testRepositoryIdentifierConstant,
+			options: githubcli.PullRequestListOptions{
+				State:       githubcli.PullRequestStateOpen,
+				BaseBranch:  testBaseBranchConstant,
+				ResultLimit: 50,
+			},
+			executor: &stubGitHubExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{StandardOutput: `[{"number":42,"title":"Example","headRefName":"feature/example"}]`}, nil
+			}},
+			verify: func(testInstance *testing.T, pullRequests []githubcli.PullRequest, executor *stubGitHubExecutor) {
+				require.Len(testInstance, pullRequests, 1)
+				require.Equal(testInstance, 42, pullRequests[0].Number)
+				require.Equal(testInstance, testPullRequestTitleConstant, pullRequests[0].Title)
+				require.Equal(testInstance, testPullRequestHeadConstant, pullRequests[0].HeadRefName)
+				require.Len(testInstance, executor.recordedDetails, 1)
+				require.Contains(testInstance, executor.recordedDetails[0].Arguments, testRepositoryIdentifierConstant)
+			},
+		},
+		{
+			name:       testListDecodeFailureCaseNameConstant,
+			repository: testRepositoryIdentifierConstant,
+			options:    githubcli.PullRequestListOptions{State: githubcli.PullRequestStateOpen, BaseBranch: testBaseBranchConstant},
+			executor: &stubGitHubExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{StandardOutput: "not-json"}, nil
+			}},
+			expectError: true,
+			errorType:   githubcli.ResponseDecodingError{},
+		},
+		{
+			name:       testListCommandFailureCaseNameConstant,
+			repository: testRepositoryIdentifierConstant,
+			options:    githubcli.PullRequestListOptions{State: githubcli.PullRequestStateClosed, BaseBranch: testBaseBranchConstant},
+			executor: &stubGitHubExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGitHub}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   githubcli.OperationError{},
+		},
+		{
+			name:        testListRepositoryValidationCaseNameConstant,
+			repository:  "",
+			options:     githubcli.PullRequestListOptions{State: githubcli.PullRequestStateOpen, BaseBranch: testBaseBranchConstant},
+			executor:    &stubGitHubExecutor{},
+			expectError: true,
+			errorType:   githubcli.InvalidInputError{},
+		},
+		{
+			name:        testListBaseValidationCaseNameConstant,
+			repository:  testRepositoryIdentifierConstant,
+			options:     githubcli.PullRequestListOptions{State: githubcli.PullRequestStateOpen, BaseBranch: " "},
+			executor:    &stubGitHubExecutor{},
+			expectError: true,
+			errorType:   githubcli.InvalidInputError{},
+		},
+		{
+			name:        testListStateValidationCaseNameConstant,
+			repository:  testRepositoryIdentifierConstant,
+			options:     githubcli.PullRequestListOptions{BaseBranch: testBaseBranchConstant},
+			executor:    &stubGitHubExecutor{},
+			expectError: true,
+			errorType:   githubcli.InvalidInputError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			client, creationError := githubcli.NewClient(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			pullRequests, listError := client.ListPullRequests(context.Background(), testCase.repository, testCase.options)
+			if testCase.expectError {
+				require.Error(testInstance, listError)
+				require.IsType(testInstance, testCase.errorType, listError)
+			} else {
+				require.NoError(testInstance, listError)
+				require.NotNil(testInstance, testCase.verify)
+				testCase.verify(testInstance, pullRequests, testCase.executor)
+			}
+		})
+	}
+}
+
+func TestUpdatePagesConfig(testInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		repository    string
+		configuration githubcli.PagesConfiguration
+		executor      *stubGitHubExecutor
+		expectError   bool
+		errorType     any
+		verify        func(testInstance *testing.T, executor *stubGitHubExecutor)
+	}{
+		{
+			name:          testPagesSuccessCaseNameConstant,
+			repository:    testRepositoryIdentifierConstant,
+			configuration: githubcli.PagesConfiguration{SourceBranch: testPagesSourceBranchConstant, SourcePath: testPagesSourcePathConstant},
+			executor: &stubGitHubExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, nil
+			}},
+			verify: func(testInstance *testing.T, executor *stubGitHubExecutor) {
+				require.Len(testInstance, executor.recordedDetails, 1)
+				require.Equal(testInstance, fmt.Sprintf("repos/%s/pages", testRepositoryIdentifierConstant), executor.recordedDetails[0].Arguments[1])
+				require.NotEmpty(testInstance, executor.recordedDetails[0].StandardInput)
+			},
+		},
+		{
+			name:          testPagesCommandFailureCaseNameConstant,
+			repository:    testRepositoryIdentifierConstant,
+			configuration: githubcli.PagesConfiguration{SourceBranch: testPagesSourceBranchConstant},
+			executor: &stubGitHubExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGitHub}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   githubcli.OperationError{},
+		},
+		{
+			name:          testPagesRepositoryValidationCaseNameConstant,
+			repository:    " ",
+			configuration: githubcli.PagesConfiguration{SourceBranch: testPagesSourceBranchConstant},
+			executor:      &stubGitHubExecutor{},
+			expectError:   true,
+			errorType:     githubcli.InvalidInputError{},
+		},
+		{
+			name:          testPagesSourceBranchValidationCaseNameConstant,
+			repository:    testRepositoryIdentifierConstant,
+			configuration: githubcli.PagesConfiguration{SourceBranch: " "},
+			executor:      &stubGitHubExecutor{},
+			expectError:   true,
+			errorType:     githubcli.InvalidInputError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			client, creationError := githubcli.NewClient(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			executionError := client.UpdatePagesConfig(context.Background(), testCase.repository, testCase.configuration)
+			if testCase.expectError {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.errorType, executionError)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.NotNil(testInstance, testCase.verify)
+				testCase.verify(testInstance, testCase.executor)
+			}
+		})
+	}
+}

--- a/internal/githubcli/doc.go
+++ b/internal/githubcli/doc.go
@@ -1,0 +1,3 @@
+// Package githubcli implements opinionated helpers for invoking the GitHub CLI using
+// the execshell executor and provides typed representations for common gh workflows.
+package githubcli

--- a/internal/gitrepo/doc.go
+++ b/internal/gitrepo/doc.go
@@ -1,0 +1,3 @@
+// Package gitrepo contains helpers for interrogating and manipulating Git repositories
+// using the execshell executor as the transport layer.
+package gitrepo

--- a/internal/gitrepo/remote_url.go
+++ b/internal/gitrepo/remote_url.go
@@ -1,0 +1,160 @@
+package gitrepo
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	sshProtocolPrefixConstant           = "ssh://"
+	sshUserDelimiterConstant            = "@"
+	sshPathDelimiterConstant            = ":"
+	httpsProtocolPrefixConstant         = "https://"
+	gitUserPrefixConstant               = "git@"
+	pathSeparatorConstant               = "/"
+	gitSuffixConstant                   = ".git"
+	remoteURLParseErrorTemplateConstant = "%s: %s"
+	invalidRemoteURLMessageConstant     = "invalid remote url"
+	unknownProtocolMessageConstant      = "unsupported remote protocol"
+)
+
+// RemoteProtocol enumerates supported git remote protocols.
+type RemoteProtocol string
+
+// Supported remote protocols.
+const (
+	RemoteProtocolSSH   RemoteProtocol = RemoteProtocol("ssh")
+	RemoteProtocolHTTPS RemoteProtocol = RemoteProtocol("https")
+)
+
+// RemoteURL represents a structured git remote URL.
+type RemoteURL struct {
+	Protocol   RemoteProtocol
+	Host       string
+	Owner      string
+	Repository string
+}
+
+// RemoteURLParseError indicates a remote string could not be parsed.
+type RemoteURLParseError struct {
+	Input   string
+	Message string
+}
+
+// Error describes the parse failure.
+func (parseError RemoteURLParseError) Error() string {
+	return fmt.Sprintf(remoteURLParseErrorTemplateConstant, parseError.Input, parseError.Message)
+}
+
+// UnsupportedProtocolError indicates the provided protocol cannot be formatted.
+type UnsupportedProtocolError struct {
+	Protocol RemoteProtocol
+}
+
+// Error describes the unsupported protocol.
+func (protocolError UnsupportedProtocolError) Error() string {
+	return fmt.Sprintf(remoteURLParseErrorTemplateConstant, protocolError.Protocol, unknownProtocolMessageConstant)
+}
+
+// ParseRemoteURL converts a textual remote URL into a structured representation.
+func ParseRemoteURL(remote string) (RemoteURL, error) {
+	trimmedRemote := strings.TrimSpace(remote)
+	if len(trimmedRemote) == 0 {
+		return RemoteURL{}, RemoteURLParseError{Input: remote, Message: requiredValueMessageConstant}
+	}
+
+	if strings.HasPrefix(trimmedRemote, sshProtocolPrefixConstant) {
+		return parseSSHRemote(strings.TrimPrefix(trimmedRemote, sshProtocolPrefixConstant))
+	}
+	if strings.HasPrefix(trimmedRemote, gitUserPrefixConstant) {
+		return parseSSHRemote(trimmedRemote)
+	}
+	if strings.HasPrefix(trimmedRemote, httpsProtocolPrefixConstant) {
+		return parseHTTPSRemote(strings.TrimPrefix(trimmedRemote, httpsProtocolPrefixConstant))
+	}
+
+	return RemoteURL{}, RemoteURLParseError{Input: remote, Message: invalidRemoteURLMessageConstant}
+}
+
+func parseSSHRemote(remote string) (RemoteURL, error) {
+	userSplitIndex := strings.Index(remote, sshUserDelimiterConstant)
+	if userSplitIndex == -1 {
+		return RemoteURL{}, RemoteURLParseError{Input: remote, Message: invalidRemoteURLMessageConstant}
+	}
+	hostAndPath := remote[userSplitIndex+1:]
+	pathSplitIndex := strings.Index(hostAndPath, sshPathDelimiterConstant)
+	var host string
+	var path string
+	if pathSplitIndex == -1 {
+		slashIndex := strings.Index(hostAndPath, pathSeparatorConstant)
+		if slashIndex == -1 {
+			return RemoteURL{}, RemoteURLParseError{Input: remote, Message: invalidRemoteURLMessageConstant}
+		}
+		host = hostAndPath[:slashIndex]
+		path = hostAndPath[slashIndex+1:]
+	} else {
+		host = hostAndPath[:pathSplitIndex]
+		path = hostAndPath[pathSplitIndex+1:]
+	}
+	owner, repository, parseError := splitOwnerAndRepository(path)
+	if parseError != nil {
+		return RemoteURL{}, parseError
+	}
+	return RemoteURL{Protocol: RemoteProtocolSSH, Host: host, Owner: owner, Repository: repository}, nil
+}
+
+func parseHTTPSRemote(remote string) (RemoteURL, error) {
+	pathComponents := strings.Split(remote, pathSeparatorConstant)
+	if len(pathComponents) < 3 {
+		return RemoteURL{}, RemoteURLParseError{Input: remote, Message: invalidRemoteURLMessageConstant}
+	}
+	host := pathComponents[0]
+	owner := pathComponents[1]
+	repository, parseError := normalizeRepositoryName(strings.Join(pathComponents[2:], pathSeparatorConstant))
+	if parseError != nil {
+		return RemoteURL{}, parseError
+	}
+	return RemoteURL{Protocol: RemoteProtocolHTTPS, Host: host, Owner: owner, Repository: repository}, nil
+}
+
+func splitOwnerAndRepository(path string) (string, string, error) {
+	segments := strings.Split(path, pathSeparatorConstant)
+	if len(segments) != 2 {
+		return "", "", RemoteURLParseError{Input: path, Message: invalidRemoteURLMessageConstant}
+	}
+	repository, parseError := normalizeRepositoryName(segments[1])
+	if parseError != nil {
+		return "", "", parseError
+	}
+	return segments[0], repository, nil
+}
+
+func normalizeRepositoryName(repository string) (string, error) {
+	trimmed := strings.TrimSuffix(repository, gitSuffixConstant)
+	if len(trimmed) == 0 {
+		return "", RemoteURLParseError{Input: repository, Message: invalidRemoteURLMessageConstant}
+	}
+	return trimmed, nil
+}
+
+// FormatRemoteURL creates a textual remote URL from a structured representation.
+func FormatRemoteURL(remote RemoteURL) (string, error) {
+	if len(strings.TrimSpace(remote.Host)) == 0 {
+		return "", RemoteURLParseError{Input: remote.Host, Message: requiredValueMessageConstant}
+	}
+	if len(strings.TrimSpace(remote.Owner)) == 0 {
+		return "", RemoteURLParseError{Input: remote.Owner, Message: requiredValueMessageConstant}
+	}
+	if len(strings.TrimSpace(remote.Repository)) == 0 {
+		return "", RemoteURLParseError{Input: remote.Repository, Message: requiredValueMessageConstant}
+	}
+
+	switch remote.Protocol {
+	case RemoteProtocolSSH:
+		return fmt.Sprintf("%s%s%s%s%s%s", gitUserPrefixConstant, remote.Host, sshPathDelimiterConstant, remote.Owner, pathSeparatorConstant, remote.Repository+gitSuffixConstant), nil
+	case RemoteProtocolHTTPS:
+		return fmt.Sprintf("%s%s%s%s%s%s%s", httpsProtocolPrefixConstant, remote.Host, pathSeparatorConstant, remote.Owner, pathSeparatorConstant, remote.Repository, gitSuffixConstant), nil
+	default:
+		return "", UnsupportedProtocolError{Protocol: remote.Protocol}
+	}
+}

--- a/internal/gitrepo/repository_manager.go
+++ b/internal/gitrepo/repository_manager.go
@@ -1,0 +1,277 @@
+package gitrepo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	gitStatusSubcommandConstant               = "status"
+	gitStatusPorcelainFlagConstant            = "--porcelain"
+	gitRevParseSubcommandConstant             = "rev-parse"
+	gitAbbrevRefFlagConstant                  = "--abbrev-ref"
+	gitHeadReferenceConstant                  = "HEAD"
+	gitCheckoutSubcommandConstant             = "checkout"
+	gitBranchSubcommandConstant               = "branch"
+	gitDeleteFlagConstant                     = "--delete"
+	gitForceFlagConstant                      = "--force"
+	gitRemoteSubcommandConstant               = "remote"
+	gitRemoteGetURLSubcommandConstant         = "get-url"
+	gitRemoteSetURLSubcommandConstant         = "set-url"
+	repositoryPathFieldNameConstant           = "repository_path"
+	branchNameFieldNameConstant               = "branch_name"
+	startPointFieldNameConstant               = "start_point"
+	remoteNameFieldNameConstant               = "remote_name"
+	remoteURLFieldNameConstant                = "remote_url"
+	requiredValueMessageConstant              = "value required"
+	executorNotConfiguredMessageConstant      = "git executor not configured"
+	repositoryOperationErrorTemplateConstant  = "%s operation failed"
+	repositoryOperationErrorWithCauseConstant = "%s operation failed: %s"
+	invalidRepositoryInputTemplateConstant    = "%s: %s"
+	cleanWorktreeOperationNameConstant        = RepositoryOperationName("CheckCleanWorktree")
+	checkoutBranchOperationNameConstant       = RepositoryOperationName("CheckoutBranch")
+	createBranchOperationNameConstant         = RepositoryOperationName("CreateBranch")
+	deleteBranchOperationNameConstant         = RepositoryOperationName("DeleteBranch")
+	currentBranchOperationNameConstant        = RepositoryOperationName("GetCurrentBranch")
+	getRemoteURLOperationNameConstant         = RepositoryOperationName("GetRemoteURL")
+	setRemoteURLOperationNameConstant         = RepositoryOperationName("SetRemoteURL")
+)
+
+// GitCommandExecutor exposes the subset of execshell functionality required by RepositoryManager.
+type GitCommandExecutor interface {
+	ExecuteGit(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error)
+}
+
+// RepositoryManager coordinates Git operations through execshell.
+type RepositoryManager struct {
+	executor GitCommandExecutor
+}
+
+var (
+	// ErrGitExecutorNotConfigured indicates the RepositoryManager was constructed without a git executor.
+	ErrGitExecutorNotConfigured = errors.New(executorNotConfiguredMessageConstant)
+)
+
+// InvalidRepositoryInputError indicates validation failures for repository operations.
+type InvalidRepositoryInputError struct {
+	FieldName string
+	Message   string
+}
+
+// Error describes the validation failure.
+func (inputError InvalidRepositoryInputError) Error() string {
+	return fmt.Sprintf(invalidRepositoryInputTemplateConstant, inputError.FieldName, inputError.Message)
+}
+
+// RepositoryOperationName captures descriptive names for repository operations.
+type RepositoryOperationName string
+
+// RepositoryOperationError wraps execution failures for git operations.
+type RepositoryOperationError struct {
+	Operation RepositoryOperationName
+	Cause     error
+}
+
+// Error describes the repository operation failure.
+func (operationError RepositoryOperationError) Error() string {
+	if operationError.Cause == nil {
+		return fmt.Sprintf(repositoryOperationErrorTemplateConstant, operationError.Operation)
+	}
+	return fmt.Sprintf(repositoryOperationErrorWithCauseConstant, operationError.Operation, operationError.Cause)
+}
+
+// Unwrap exposes the underlying error.
+func (operationError RepositoryOperationError) Unwrap() error {
+	return operationError.Cause
+}
+
+// NewRepositoryManager constructs a RepositoryManager for the provided executor.
+func NewRepositoryManager(executor GitCommandExecutor) (*RepositoryManager, error) {
+	if executor == nil {
+		return nil, ErrGitExecutorNotConfigured
+	}
+	return &RepositoryManager{executor: executor}, nil
+}
+
+// CheckCleanWorktree returns true when the repository has no staged or unstaged changes.
+func (manager *RepositoryManager) CheckCleanWorktree(executionContext context.Context, repositoryPath string) (bool, error) {
+	trimmedPath := strings.TrimSpace(repositoryPath)
+	if len(trimmedPath) == 0 {
+		return false, InvalidRepositoryInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        []string{gitStatusSubcommandConstant, gitStatusPorcelainFlagConstant},
+		WorkingDirectory: trimmedPath,
+	}
+
+	executionResult, executionError := manager.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return false, RepositoryOperationError{Operation: cleanWorktreeOperationNameConstant, Cause: executionError}
+	}
+
+	trimmedOutput := strings.TrimSpace(executionResult.StandardOutput)
+	return len(trimmedOutput) == 0, nil
+}
+
+// CheckoutBranch checks out an existing branch.
+func (manager *RepositoryManager) CheckoutBranch(executionContext context.Context, repositoryPath string, branchName string) error {
+	trimmedPath := strings.TrimSpace(repositoryPath)
+	if len(trimmedPath) == 0 {
+		return InvalidRepositoryInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedBranch := strings.TrimSpace(branchName)
+	if len(trimmedBranch) == 0 {
+		return InvalidRepositoryInputError{FieldName: branchNameFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        []string{gitCheckoutSubcommandConstant, trimmedBranch},
+		WorkingDirectory: trimmedPath,
+	}
+
+	_, executionError := manager.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return RepositoryOperationError{Operation: checkoutBranchOperationNameConstant, Cause: executionError}
+	}
+	return nil
+}
+
+// CreateBranch creates a new branch optionally from a start point.
+func (manager *RepositoryManager) CreateBranch(executionContext context.Context, repositoryPath string, branchName string, startPoint string) error {
+	trimmedPath := strings.TrimSpace(repositoryPath)
+	if len(trimmedPath) == 0 {
+		return InvalidRepositoryInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedBranch := strings.TrimSpace(branchName)
+	if len(trimmedBranch) == 0 {
+		return InvalidRepositoryInputError{FieldName: branchNameFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandArguments := []string{gitBranchSubcommandConstant, trimmedBranch}
+	trimmedStartPoint := strings.TrimSpace(startPoint)
+	if len(trimmedStartPoint) > 0 {
+		commandArguments = append(commandArguments, trimmedStartPoint)
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        commandArguments,
+		WorkingDirectory: trimmedPath,
+	}
+
+	_, executionError := manager.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return RepositoryOperationError{Operation: createBranchOperationNameConstant, Cause: executionError}
+	}
+	return nil
+}
+
+// DeleteBranch removes a local branch. When forceDelete is true the deletion is forced.
+func (manager *RepositoryManager) DeleteBranch(executionContext context.Context, repositoryPath string, branchName string, forceDelete bool) error {
+	trimmedPath := strings.TrimSpace(repositoryPath)
+	if len(trimmedPath) == 0 {
+		return InvalidRepositoryInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedBranch := strings.TrimSpace(branchName)
+	if len(trimmedBranch) == 0 {
+		return InvalidRepositoryInputError{FieldName: branchNameFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandArguments := []string{gitBranchSubcommandConstant, gitDeleteFlagConstant}
+	if forceDelete {
+		commandArguments = append(commandArguments, gitForceFlagConstant)
+	}
+	commandArguments = append(commandArguments, trimmedBranch)
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        commandArguments,
+		WorkingDirectory: trimmedPath,
+	}
+
+	_, executionError := manager.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return RepositoryOperationError{Operation: deleteBranchOperationNameConstant, Cause: executionError}
+	}
+	return nil
+}
+
+// GetCurrentBranch resolves the current branch name.
+func (manager *RepositoryManager) GetCurrentBranch(executionContext context.Context, repositoryPath string) (string, error) {
+	trimmedPath := strings.TrimSpace(repositoryPath)
+	if len(trimmedPath) == 0 {
+		return "", InvalidRepositoryInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        []string{gitRevParseSubcommandConstant, gitAbbrevRefFlagConstant, gitHeadReferenceConstant},
+		WorkingDirectory: trimmedPath,
+	}
+
+	executionResult, executionError := manager.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return "", RepositoryOperationError{Operation: currentBranchOperationNameConstant, Cause: executionError}
+	}
+
+	return strings.TrimSpace(executionResult.StandardOutput), nil
+}
+
+// GetRemoteURL returns the configured remote URL for the given remote name.
+func (manager *RepositoryManager) GetRemoteURL(executionContext context.Context, repositoryPath string, remoteName string) (string, error) {
+	trimmedPath := strings.TrimSpace(repositoryPath)
+	if len(trimmedPath) == 0 {
+		return "", InvalidRepositoryInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedRemote := strings.TrimSpace(remoteName)
+	if len(trimmedRemote) == 0 {
+		return "", InvalidRepositoryInputError{FieldName: remoteNameFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        []string{gitRemoteSubcommandConstant, gitRemoteGetURLSubcommandConstant, trimmedRemote},
+		WorkingDirectory: trimmedPath,
+	}
+
+	executionResult, executionError := manager.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return "", RepositoryOperationError{Operation: getRemoteURLOperationNameConstant, Cause: executionError}
+	}
+
+	return strings.TrimSpace(executionResult.StandardOutput), nil
+}
+
+// SetRemoteURL sets the remote URL for a remote.
+func (manager *RepositoryManager) SetRemoteURL(executionContext context.Context, repositoryPath string, remoteName string, remoteURL string) error {
+	trimmedPath := strings.TrimSpace(repositoryPath)
+	if len(trimmedPath) == 0 {
+		return InvalidRepositoryInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedRemote := strings.TrimSpace(remoteName)
+	if len(trimmedRemote) == 0 {
+		return InvalidRepositoryInputError{FieldName: remoteNameFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedRemoteURL := strings.TrimSpace(remoteURL)
+	if len(trimmedRemoteURL) == 0 {
+		return InvalidRepositoryInputError{FieldName: remoteURLFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        []string{gitRemoteSubcommandConstant, gitRemoteSetURLSubcommandConstant, trimmedRemote, trimmedRemoteURL},
+		WorkingDirectory: trimmedPath,
+	}
+
+	_, executionError := manager.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return RepositoryOperationError{Operation: setRemoteURLOperationNameConstant, Cause: executionError}
+	}
+	return nil
+}

--- a/internal/gitrepo/repository_manager_test.go
+++ b/internal/gitrepo/repository_manager_test.go
@@ -1,0 +1,494 @@
+package gitrepo_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/gitrepo"
+)
+
+const (
+	testRepositoryPathConstant                = "/tmp/repo"
+	testBranchNameConstant                    = "feature/example"
+	testStartPointConstant                    = "origin/main"
+	testRemoteNameConstant                    = "origin"
+	testRemoteURLConstant                     = "git@github.com:owner/example.git"
+	testCleanWorktreeCaseNameConstant         = "clean"
+	testDirtyWorktreeCaseNameConstant         = "dirty"
+	testWorktreeErrorCaseNameConstant         = "error"
+	testValidationCaseNameConstant            = "validation"
+	testCheckoutSuccessCaseNameConstant       = "checkout_success"
+	testCheckoutErrorCaseNameConstant         = "checkout_error"
+	testCreateBranchSuccessCaseNameConstant   = "create_branch_success"
+	testCreateBranchWithStartCaseNameConstant = "create_branch_start"
+	testCreateBranchErrorCaseNameConstant     = "create_branch_error"
+	testDeleteBranchForcedCaseNameConstant    = "delete_branch_forced"
+	testDeleteBranchStandardCaseNameConstant  = "delete_branch_standard"
+	testDeleteBranchErrorCaseNameConstant     = "delete_branch_error"
+	testCurrentBranchSuccessCaseNameConstant  = "current_branch_success"
+	testCurrentBranchErrorCaseNameConstant    = "current_branch_error"
+	testGetRemoteSuccessCaseNameConstant      = "get_remote_success"
+	testGetRemoteErrorCaseNameConstant        = "get_remote_error"
+	testSetRemoteSuccessCaseNameConstant      = "set_remote_success"
+	testSetRemoteErrorCaseNameConstant        = "set_remote_error"
+	testParseRemoteSuccessCaseNameConstant    = "parse_remote_success"
+	testParseRemoteErrorCaseNameConstant      = "parse_remote_error"
+	testFormatRemoteSuccessCaseNameConstant   = "format_remote_success"
+	testFormatRemoteErrorCaseNameConstant     = "format_remote_error"
+)
+
+type stubGitExecutor struct {
+	executeFunc     func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error)
+	recordedDetails []execshell.CommandDetails
+}
+
+func (executor *stubGitExecutor) ExecuteGit(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	executor.recordedDetails = append(executor.recordedDetails, details)
+	if executor.executeFunc != nil {
+		return executor.executeFunc(executionContext, details)
+	}
+	return execshell.ExecutionResult{}, nil
+}
+
+func TestNewRepositoryManagerValidation(testInstance *testing.T) {
+	testInstance.Run(testValidationCaseNameConstant, func(testInstance *testing.T) {
+		manager, creationError := gitrepo.NewRepositoryManager(nil)
+		require.Error(testInstance, creationError)
+		require.ErrorIs(testInstance, creationError, gitrepo.ErrGitExecutorNotConfigured)
+		require.Nil(testInstance, manager)
+	})
+}
+
+func TestCheckCleanWorktree(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		executor    *stubGitExecutor
+		expected    bool
+		expectError bool
+		errorType   any
+	}{
+		{
+			name: testCleanWorktreeCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{StandardOutput: ""}, nil
+			}},
+			expected: true,
+		},
+		{
+			name: testDirtyWorktreeCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{StandardOutput: " M file.txt"}, nil
+			}},
+			expected: false,
+		},
+		{
+			name: testWorktreeErrorCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGit}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   gitrepo.RepositoryOperationError{},
+		},
+		{
+			name:        testValidationCaseNameConstant,
+			executor:    &stubGitExecutor{},
+			expectError: true,
+			errorType:   gitrepo.InvalidRepositoryInputError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			manager, creationError := gitrepo.NewRepositoryManager(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			clean, checkError := manager.CheckCleanWorktree(context.Background(), func() string {
+				if testCase.name == testValidationCaseNameConstant {
+					return ""
+				}
+				return testRepositoryPathConstant
+			}())
+
+			if testCase.expectError {
+				require.Error(testInstance, checkError)
+				require.IsType(testInstance, testCase.errorType, checkError)
+			} else {
+				require.NoError(testInstance, checkError)
+				require.Equal(testInstance, testCase.expected, clean)
+				require.Len(testInstance, testCase.executor.recordedDetails, 1)
+			}
+		})
+	}
+}
+
+func TestCheckoutBranch(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		executor    *stubGitExecutor
+		expectError bool
+		errorType   any
+	}{
+		{
+			name: testCheckoutSuccessCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, nil
+			}},
+		},
+		{
+			name: testCheckoutErrorCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGit}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   gitrepo.RepositoryOperationError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			manager, creationError := gitrepo.NewRepositoryManager(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			executionError := manager.CheckoutBranch(context.Background(), testRepositoryPathConstant, testBranchNameConstant)
+			if testCase.expectError {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.errorType, executionError)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.Len(testInstance, testCase.executor.recordedDetails, 1)
+				require.Contains(testInstance, testCase.executor.recordedDetails[0].Arguments, testBranchNameConstant)
+			}
+		})
+	}
+}
+
+func TestCreateBranch(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		branchName  string
+		startPoint  string
+		executor    *stubGitExecutor
+		expectError bool
+		errorType   any
+		verify      func(testInstance *testing.T, executor *stubGitExecutor)
+	}{
+		{
+			name:       testCreateBranchSuccessCaseNameConstant,
+			branchName: testBranchNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, nil
+			}},
+			verify: func(testInstance *testing.T, executor *stubGitExecutor) {
+				require.Len(testInstance, executor.recordedDetails, 1)
+				require.Contains(testInstance, executor.recordedDetails[0].Arguments, testBranchNameConstant)
+			},
+		},
+		{
+			name:       testCreateBranchWithStartCaseNameConstant,
+			branchName: testBranchNameConstant,
+			startPoint: testStartPointConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, nil
+			}},
+			verify: func(testInstance *testing.T, executor *stubGitExecutor) {
+				require.Len(testInstance, executor.recordedDetails, 1)
+				require.Contains(testInstance, executor.recordedDetails[0].Arguments, testStartPointConstant)
+			},
+		},
+		{
+			name:       testCreateBranchErrorCaseNameConstant,
+			branchName: testBranchNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGit}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   gitrepo.RepositoryOperationError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			manager, creationError := gitrepo.NewRepositoryManager(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			executionError := manager.CreateBranch(context.Background(), testRepositoryPathConstant, testCase.branchName, testCase.startPoint)
+			if testCase.expectError {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.errorType, executionError)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.NotNil(testInstance, testCase.verify)
+				testCase.verify(testInstance, testCase.executor)
+			}
+		})
+	}
+}
+
+func TestDeleteBranch(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		forceDelete bool
+		executor    *stubGitExecutor
+		expectError bool
+		errorType   any
+	}{
+		{
+			name:        testDeleteBranchForcedCaseNameConstant,
+			forceDelete: true,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, nil
+			}},
+		},
+		{
+			name: testDeleteBranchStandardCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, nil
+			}},
+		},
+		{
+			name: testDeleteBranchErrorCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGit}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   gitrepo.RepositoryOperationError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			manager, creationError := gitrepo.NewRepositoryManager(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			executionError := manager.DeleteBranch(context.Background(), testRepositoryPathConstant, testBranchNameConstant, testCase.forceDelete)
+			if testCase.expectError {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.errorType, executionError)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.Len(testInstance, testCase.executor.recordedDetails, 1)
+				if testCase.forceDelete {
+					require.Contains(testInstance, testCase.executor.recordedDetails[0].Arguments, "--force")
+				}
+			}
+		})
+	}
+}
+
+func TestGetCurrentBranch(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		executor    *stubGitExecutor
+		expectError bool
+		errorType   any
+		expected    string
+	}{
+		{
+			name: testCurrentBranchSuccessCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{StandardOutput: "main\n"}, nil
+			}},
+			expected: "main",
+		},
+		{
+			name: testCurrentBranchErrorCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGit}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   gitrepo.RepositoryOperationError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			manager, creationError := gitrepo.NewRepositoryManager(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			branchName, executionError := manager.GetCurrentBranch(context.Background(), testRepositoryPathConstant)
+			if testCase.expectError {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.errorType, executionError)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.Equal(testInstance, testCase.expected, branchName)
+			}
+		})
+	}
+}
+
+func TestGetRemoteURL(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		executor    *stubGitExecutor
+		expectError bool
+		errorType   any
+		expected    string
+	}{
+		{
+			name: testGetRemoteSuccessCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{StandardOutput: testRemoteURLConstant + "\n"}, nil
+			}},
+			expected: testRemoteURLConstant,
+		},
+		{
+			name: testGetRemoteErrorCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGit}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   gitrepo.RepositoryOperationError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			manager, creationError := gitrepo.NewRepositoryManager(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			remoteURL, executionError := manager.GetRemoteURL(context.Background(), testRepositoryPathConstant, testRemoteNameConstant)
+			if testCase.expectError {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.errorType, executionError)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.Equal(testInstance, testCase.expected, remoteURL)
+			}
+		})
+	}
+}
+
+func TestSetRemoteURL(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		executor    *stubGitExecutor
+		expectError bool
+		errorType   any
+	}{
+		{
+			name: testSetRemoteSuccessCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, nil
+			}},
+		},
+		{
+			name: testSetRemoteErrorCaseNameConstant,
+			executor: &stubGitExecutor{executeFunc: func(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+				return execshell.ExecutionResult{}, execshell.CommandExecutionError{Command: execshell.ShellCommand{Name: execshell.CommandGit}, Cause: errors.New("failed")}
+			}},
+			expectError: true,
+			errorType:   gitrepo.RepositoryOperationError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			manager, creationError := gitrepo.NewRepositoryManager(testCase.executor)
+			require.NoError(testInstance, creationError)
+
+			executionError := manager.SetRemoteURL(context.Background(), testRepositoryPathConstant, testRemoteNameConstant, testRemoteURLConstant)
+			if testCase.expectError {
+				require.Error(testInstance, executionError)
+				require.IsType(testInstance, testCase.errorType, executionError)
+			} else {
+				require.NoError(testInstance, executionError)
+				require.Len(testInstance, testCase.executor.recordedDetails, 1)
+				require.Contains(testInstance, testCase.executor.recordedDetails[0].Arguments, testRemoteURLConstant)
+			}
+		})
+	}
+}
+
+func TestParseRemoteURL(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expected    gitrepo.RemoteURL
+		expectError bool
+	}{
+		{
+			name:     testParseRemoteSuccessCaseNameConstant,
+			input:    "git@github.com:owner/example.git",
+			expected: gitrepo.RemoteURL{Protocol: gitrepo.RemoteProtocolSSH, Host: "github.com", Owner: "owner", Repository: "example"},
+		},
+		{
+			name:     "ssh_scheme_prefix",
+			input:    "ssh://git@github.com/owner/example.git",
+			expected: gitrepo.RemoteURL{Protocol: gitrepo.RemoteProtocolSSH, Host: "github.com", Owner: "owner", Repository: "example"},
+		},
+		{
+			name:     "https_protocol",
+			input:    "https://github.com/owner/example.git",
+			expected: gitrepo.RemoteURL{Protocol: gitrepo.RemoteProtocolHTTPS, Host: "github.com", Owner: "owner", Repository: "example"},
+		},
+		{
+			name:        testParseRemoteErrorCaseNameConstant,
+			input:       "invalid",
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			remoteURL, parseError := gitrepo.ParseRemoteURL(testCase.input)
+			if testCase.expectError {
+				require.Error(testInstance, parseError)
+				require.IsType(testInstance, gitrepo.RemoteURLParseError{}, parseError)
+			} else {
+				require.NoError(testInstance, parseError)
+				require.Equal(testInstance, testCase.expected, remoteURL)
+			}
+		})
+	}
+}
+
+func TestFormatRemoteURL(testInstance *testing.T) {
+	testCases := []struct {
+		name        string
+		input       gitrepo.RemoteURL
+		expected    string
+		expectError bool
+		errorType   any
+	}{
+		{
+			name:     testFormatRemoteSuccessCaseNameConstant,
+			input:    gitrepo.RemoteURL{Protocol: gitrepo.RemoteProtocolSSH, Host: "github.com", Owner: "owner", Repository: "example"},
+			expected: "git@github.com:owner/example.git",
+		},
+		{
+			name:     "https_protocol",
+			input:    gitrepo.RemoteURL{Protocol: gitrepo.RemoteProtocolHTTPS, Host: "github.com", Owner: "owner", Repository: "example"},
+			expected: "https://github.com/owner/example.git",
+		},
+		{
+			name:        testFormatRemoteErrorCaseNameConstant,
+			input:       gitrepo.RemoteURL{Protocol: gitrepo.RemoteProtocolSSH, Host: "", Owner: "owner", Repository: "example"},
+			expectError: true,
+			errorType:   gitrepo.RemoteURLParseError{},
+		},
+		{
+			name:        "unsupported_protocol",
+			input:       gitrepo.RemoteURL{Protocol: gitrepo.RemoteProtocol("git"), Host: "github.com", Owner: "owner", Repository: "example"},
+			expectError: true,
+			errorType:   gitrepo.UnsupportedProtocolError{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			formatted, formatError := gitrepo.FormatRemoteURL(testCase.input)
+			if testCase.expectError {
+				require.Error(testInstance, formatError)
+				require.IsType(testInstance, testCase.errorType, formatError)
+			} else {
+				require.NoError(testInstance, formatError)
+				require.Equal(testInstance, testCase.expected, formatted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add the execshell package to execute git/gh/curl commands with structured logging and typed errors
- introduce a githubcli client that shells out to gh for metadata, pull requests, and Pages updates with table-driven tests
- provide gitrepo helpers for clean worktree checks, branch management, and remote URL parsing along with comprehensive tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1df9a3bc88327b1d5df900eabb586