### PR TITLE
Improve console logging and command events

### DIFF
--- a/cmd/cli/repos/group.go
+++ b/cmd/cli/repos/group.go
@@ -1,6 +1,10 @@
 package repos
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+)
 
 const (
 	groupUseConstant      = "repos"
@@ -10,7 +14,8 @@ const (
 
 // CommandGroupBuilder assembles the repos command group.
 type CommandGroupBuilder struct {
-	LoggerProvider LoggerProvider
+	LoggerProvider        LoggerProvider
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the repos command hierarchy.
@@ -21,19 +26,19 @@ func (builder *CommandGroupBuilder) Build() (*cobra.Command, error) {
 		Long:  groupLongDescription,
 	}
 
-	renameBuilder := RenameCommandBuilder{LoggerProvider: builder.LoggerProvider}
+	renameBuilder := RenameCommandBuilder{LoggerProvider: builder.LoggerProvider, CommandEventsObserver: builder.CommandEventsObserver}
 	renameCommand, renameError := renameBuilder.Build()
 	if renameError == nil {
 		command.AddCommand(renameCommand)
 	}
 
-	remotesBuilder := RemotesCommandBuilder{LoggerProvider: builder.LoggerProvider}
+	remotesBuilder := RemotesCommandBuilder{LoggerProvider: builder.LoggerProvider, CommandEventsObserver: builder.CommandEventsObserver}
 	remotesCommand, remotesError := remotesBuilder.Build()
 	if remotesError == nil {
 		command.AddCommand(remotesCommand)
 	}
 
-	protocolBuilder := ProtocolCommandBuilder{LoggerProvider: builder.LoggerProvider}
+	protocolBuilder := ProtocolCommandBuilder{LoggerProvider: builder.LoggerProvider, CommandEventsObserver: builder.CommandEventsObserver}
 	protocolCommand, protocolError := protocolBuilder.Build()
 	if protocolError == nil {
 		command.AddCommand(protocolCommand)

--- a/cmd/cli/repos/protocol.go
+++ b/cmd/cli/repos/protocol.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/temirov/git_scripts/internal/audit"
+	"github.com/temirov/git_scripts/internal/execshell"
 	"github.com/temirov/git_scripts/internal/repos/dependencies"
 	conversion "github.com/temirov/git_scripts/internal/repos/protocol"
 	"github.com/temirov/git_scripts/internal/repos/shared"
@@ -33,12 +34,13 @@ const (
 
 // ProtocolCommandBuilder assembles the convert-remote-protocol command.
 type ProtocolCommandBuilder struct {
-	LoggerProvider  LoggerProvider
-	Discoverer      shared.RepositoryDiscoverer
-	GitExecutor     shared.GitExecutor
-	GitManager      shared.GitRepositoryManager
-	GitHubResolver  shared.GitHubMetadataResolver
-	PrompterFactory PrompterFactory
+	LoggerProvider        LoggerProvider
+	Discoverer            shared.RepositoryDiscoverer
+	GitExecutor           shared.GitExecutor
+	GitManager            shared.GitRepositoryManager
+	GitHubResolver        shared.GitHubMetadataResolver
+	PrompterFactory       PrompterFactory
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the convert-remote-protocol command.
@@ -85,7 +87,7 @@ func (builder *ProtocolCommandBuilder) run(command *cobra.Command, arguments []s
 	roots := determineRepositoryRoots(arguments)
 
 	logger := resolveLogger(builder.LoggerProvider)
-	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger)
+	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger, builder.CommandEventsObserver)
 	if executorError != nil {
 		return executorError
 	}

--- a/cmd/cli/repos/remotes.go
+++ b/cmd/cli/repos/remotes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/temirov/git_scripts/internal/audit"
+	"github.com/temirov/git_scripts/internal/execshell"
 	"github.com/temirov/git_scripts/internal/repos/dependencies"
 	"github.com/temirov/git_scripts/internal/repos/remotes"
 	"github.com/temirov/git_scripts/internal/repos/shared"
@@ -24,12 +25,13 @@ const (
 
 // RemotesCommandBuilder assembles the update-canonical-remote command.
 type RemotesCommandBuilder struct {
-	LoggerProvider  LoggerProvider
-	Discoverer      shared.RepositoryDiscoverer
-	GitExecutor     shared.GitExecutor
-	GitManager      shared.GitRepositoryManager
-	GitHubResolver  shared.GitHubMetadataResolver
-	PrompterFactory PrompterFactory
+	LoggerProvider        LoggerProvider
+	Discoverer            shared.RepositoryDiscoverer
+	GitExecutor           shared.GitExecutor
+	GitManager            shared.GitRepositoryManager
+	GitHubResolver        shared.GitHubMetadataResolver
+	PrompterFactory       PrompterFactory
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the update-canonical-remote command.
@@ -53,7 +55,7 @@ func (builder *RemotesCommandBuilder) run(command *cobra.Command, arguments []st
 	roots := determineRepositoryRoots(arguments)
 
 	logger := resolveLogger(builder.LoggerProvider)
-	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger)
+	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger, builder.CommandEventsObserver)
 	if executorError != nil {
 		return executorError
 	}

--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/temirov/git_scripts/internal/audit"
+	"github.com/temirov/git_scripts/internal/execshell"
 	"github.com/temirov/git_scripts/internal/repos/dependencies"
 	"github.com/temirov/git_scripts/internal/repos/rename"
 	"github.com/temirov/git_scripts/internal/repos/shared"
@@ -26,13 +27,14 @@ const (
 
 // RenameCommandBuilder assembles the rename-folders command.
 type RenameCommandBuilder struct {
-	LoggerProvider  LoggerProvider
-	Discoverer      shared.RepositoryDiscoverer
-	GitExecutor     shared.GitExecutor
-	GitManager      shared.GitRepositoryManager
-	GitHubResolver  shared.GitHubMetadataResolver
-	FileSystem      shared.FileSystem
-	PrompterFactory PrompterFactory
+	LoggerProvider        LoggerProvider
+	Discoverer            shared.RepositoryDiscoverer
+	GitExecutor           shared.GitExecutor
+	GitManager            shared.GitRepositoryManager
+	GitHubResolver        shared.GitHubMetadataResolver
+	FileSystem            shared.FileSystem
+	PrompterFactory       PrompterFactory
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the rename-folders command.
@@ -59,7 +61,7 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 	roots := determineRepositoryRoots(arguments)
 
 	logger := resolveLogger(builder.LoggerProvider)
-	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger)
+	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger, builder.CommandEventsObserver)
 	if executorError != nil {
 		return executorError
 	}

--- a/cmd/cli/workflow/run.go
+++ b/cmd/cli/workflow/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/temirov/git_scripts/internal/execshell"
 	"github.com/temirov/git_scripts/internal/githubcli"
 	"github.com/temirov/git_scripts/internal/gitrepo"
 	"github.com/temirov/git_scripts/internal/repos/dependencies"
@@ -36,11 +37,12 @@ const (
 
 // CommandBuilder assembles the workflow command hierarchy.
 type CommandBuilder struct {
-	LoggerProvider  LoggerProvider
-	Discoverer      shared.RepositoryDiscoverer
-	GitExecutor     shared.GitExecutor
-	FileSystem      shared.FileSystem
-	PrompterFactory PrompterFactory
+	LoggerProvider        LoggerProvider
+	Discoverer            shared.RepositoryDiscoverer
+	GitExecutor           shared.GitExecutor
+	FileSystem            shared.FileSystem
+	PrompterFactory       PrompterFactory
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the workflow command group.
@@ -84,7 +86,7 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 	}
 
 	logger := resolveLogger(builder.LoggerProvider)
-	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger)
+	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger, builder.CommandEventsObserver)
 	if executorError != nil {
 		return executorError
 	}

--- a/internal/audit/command.go
+++ b/internal/audit/command.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/temirov/git_scripts/internal/execshell"
 	"github.com/temirov/git_scripts/internal/repos/dependencies"
 )
 
@@ -14,11 +15,12 @@ type LoggerProvider func() *zap.Logger
 
 // CommandBuilder assembles the audit cobra command with configurable dependencies.
 type CommandBuilder struct {
-	LoggerProvider LoggerProvider
-	Discoverer     RepositoryDiscoverer
-	GitExecutor    GitExecutor
-	GitManager     GitRepositoryManager
-	GitHubResolver GitHubMetadataResolver
+	LoggerProvider        LoggerProvider
+	Discoverer            RepositoryDiscoverer
+	GitExecutor           GitExecutor
+	GitManager            GitRepositoryManager
+	GitHubResolver        GitHubMetadataResolver
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the cobra command for repository audit workflows.
@@ -95,7 +97,7 @@ func (builder *CommandBuilder) resolveLogger() *zap.Logger {
 }
 
 func (builder *CommandBuilder) resolveGitExecutor(logger *zap.Logger) (GitExecutor, error) {
-	return dependencies.ResolveGitExecutor(builder.GitExecutor, logger)
+	return dependencies.ResolveGitExecutor(builder.GitExecutor, logger, builder.CommandEventsObserver)
 }
 
 func (builder *CommandBuilder) resolveGitManager(executor GitExecutor) (GitRepositoryManager, error) {

--- a/internal/branches/command.go
+++ b/internal/branches/command.go
@@ -41,10 +41,11 @@ type LoggerProvider func() *zap.Logger
 
 // CommandBuilder assembles the Cobra command for branch cleanup.
 type CommandBuilder struct {
-	LoggerProvider       LoggerProvider
-	Executor             CommandExecutor
-	WorkingDirectory     string
-	RepositoryDiscoverer RepositoryDiscoverer
+	LoggerProvider        LoggerProvider
+	Executor              CommandExecutor
+	WorkingDirectory      string
+	RepositoryDiscoverer  RepositoryDiscoverer
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the pr-cleanup command.
@@ -160,7 +161,7 @@ func (builder *CommandBuilder) resolveExecutor(logger *zap.Logger) (CommandExecu
 	}
 
 	commandRunner := execshell.NewOSCommandRunner()
-	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner)
+	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner, builder.CommandEventsObserver)
 	if creationError != nil {
 		return nil, creationError
 	}

--- a/internal/execshell/command_events.go
+++ b/internal/execshell/command_events.go
@@ -1,0 +1,23 @@
+package execshell
+
+// CommandEventObserver receives lifecycle notifications for shell command execution.
+type CommandEventObserver interface {
+	// CommandStarted notifies observers that command execution is beginning.
+	CommandStarted(command ShellCommand)
+	// CommandCompleted notifies observers that command execution finished and supplies the result.
+	CommandCompleted(command ShellCommand, result ExecutionResult)
+	// CommandExecutionFailed reports unexpected failures prior to receiving an execution result.
+	CommandExecutionFailed(command ShellCommand, failure error)
+}
+
+// noopCommandEventObserver discards all command events.
+type noopCommandEventObserver struct{}
+
+// CommandStarted implements CommandEventObserver for the no-op observer.
+func (noopCommandEventObserver) CommandStarted(ShellCommand) {}
+
+// CommandCompleted implements CommandEventObserver for the no-op observer.
+func (noopCommandEventObserver) CommandCompleted(ShellCommand, ExecutionResult) {}
+
+// CommandExecutionFailed implements CommandEventObserver for the no-op observer.
+func (noopCommandEventObserver) CommandExecutionFailed(ShellCommand, error) {}

--- a/internal/migrate/command.go
+++ b/internal/migrate/command.go
@@ -67,11 +67,12 @@ type LoggerProvider func() *zap.Logger
 
 // CommandBuilder assembles the Cobra command hierarchy for branch migration.
 type CommandBuilder struct {
-	LoggerProvider       LoggerProvider
-	Executor             CommandExecutor
-	WorkingDirectory     string
-	RepositoryDiscoverer RepositoryDiscoverer
-	ServiceProvider      ServiceProvider
+	LoggerProvider        LoggerProvider
+	Executor              CommandExecutor
+	WorkingDirectory      string
+	RepositoryDiscoverer  RepositoryDiscoverer
+	ServiceProvider       ServiceProvider
+	CommandEventsObserver execshell.CommandEventObserver
 }
 
 // Build constructs the branch command with the migrate subcommand.
@@ -248,7 +249,7 @@ func (builder *CommandBuilder) resolveExecutor(logger *zap.Logger) (CommandExecu
 	}
 
 	commandRunner := execshell.NewOSCommandRunner()
-	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner)
+	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner, builder.CommandEventsObserver)
 	if creationError != nil {
 		return nil, creationError
 	}

--- a/internal/repos/dependencies/resolve.go
+++ b/internal/repos/dependencies/resolve.go
@@ -27,13 +27,13 @@ func ResolveFileSystem(existing shared.FileSystem) shared.FileSystem {
 }
 
 // ResolveGitExecutor returns the provided executor or constructs a shell-backed default.
-func ResolveGitExecutor(existing shared.GitExecutor, logger *zap.Logger) (shared.GitExecutor, error) {
+func ResolveGitExecutor(existing shared.GitExecutor, logger *zap.Logger, eventsObserver execshell.CommandEventObserver) (shared.GitExecutor, error) {
 	if existing != nil {
 		return existing, nil
 	}
 
 	commandRunner := execshell.NewOSCommandRunner()
-	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner)
+	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner, eventsObserver)
 	if creationError != nil {
 		return nil, creationError
 	}

--- a/internal/ui/command_events.go
+++ b/internal/ui/command_events.go
@@ -1,0 +1,123 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	commandStartedMessageTemplateConstant          = "Running %s"
+	commandCompletedMessageTemplateConstant        = "Completed %s"
+	commandFailedExitCodeMessageTemplateConstant   = "%s failed with exit code %d"
+	commandExecutionFailureMessageTemplateConstant = "%s failed: %s"
+	commandLabelTemplateConstant                   = "%s%s"
+	workingDirectorySuffixTemplateConstant         = " (in %s)"
+	commandArgumentsJoinSeparatorConstant          = " "
+	standardErrorSuffixTemplateConstant            = ": %s"
+	unknownFailureMessageConstant                  = "unknown error"
+	emptyStringConstant                            = ""
+)
+
+// CommandEventFormatter builds human-readable messages for command lifecycle events.
+type CommandEventFormatter struct{}
+
+// BuildStartedMessage formats the message describing a command about to run.
+func (formatter CommandEventFormatter) BuildStartedMessage(command execshell.ShellCommand) string {
+	return fmt.Sprintf(commandStartedMessageTemplateConstant, formatter.formatCommandLabel(command))
+}
+
+// BuildSuccessMessage formats the message describing a completed command with a zero exit code.
+func (formatter CommandEventFormatter) BuildSuccessMessage(command execshell.ShellCommand) string {
+	return fmt.Sprintf(commandCompletedMessageTemplateConstant, formatter.formatCommandLabel(command))
+}
+
+// BuildFailureMessage formats the message describing a command that returned a non-zero exit code.
+func (formatter CommandEventFormatter) BuildFailureMessage(command execshell.ShellCommand, result execshell.ExecutionResult) string {
+	baseMessage := fmt.Sprintf(commandFailedExitCodeMessageTemplateConstant, formatter.formatCommandLabel(command), result.ExitCode)
+	standardErrorSuffix := formatter.formatStandardErrorSuffix(result.StandardError)
+	if len(standardErrorSuffix) == 0 {
+		return baseMessage
+	}
+	return baseMessage + standardErrorSuffix
+}
+
+// BuildExecutionFailureMessage formats the message describing an unexpected execution failure.
+func (formatter CommandEventFormatter) BuildExecutionFailureMessage(command execshell.ShellCommand, failure error) string {
+	failureMessage := unknownFailureMessageConstant
+	if failure != nil {
+		failureMessage = failure.Error()
+	}
+	return fmt.Sprintf(commandExecutionFailureMessageTemplateConstant, formatter.formatCommandLabel(command), failureMessage)
+}
+
+func (formatter CommandEventFormatter) formatCommandLabel(command execshell.ShellCommand) string {
+	commandParts := []string{string(command.Name)}
+	if len(command.Details.Arguments) > 0 {
+		commandParts = append(commandParts, strings.Join(command.Details.Arguments, commandArgumentsJoinSeparatorConstant))
+	}
+	commandLabel := strings.Join(commandParts, commandArgumentsJoinSeparatorConstant)
+	workingDirectorySuffix := formatter.formatWorkingDirectorySuffix(command)
+	return fmt.Sprintf(commandLabelTemplateConstant, commandLabel, workingDirectorySuffix)
+}
+
+func (formatter CommandEventFormatter) formatWorkingDirectorySuffix(command execshell.ShellCommand) string {
+	trimmedWorkingDirectory := strings.TrimSpace(command.Details.WorkingDirectory)
+	if len(trimmedWorkingDirectory) == 0 {
+		return emptyStringConstant
+	}
+	return fmt.Sprintf(workingDirectorySuffixTemplateConstant, trimmedWorkingDirectory)
+}
+
+func (formatter CommandEventFormatter) formatStandardErrorSuffix(standardError string) string {
+	trimmedStandardError := strings.TrimSpace(standardError)
+	if len(trimmedStandardError) == 0 {
+		return emptyStringConstant
+	}
+	return fmt.Sprintf(standardErrorSuffixTemplateConstant, trimmedStandardError)
+}
+
+// ConsoleCommandEventLogger renders command lifecycle events using a zap logger configured for human-readable output.
+type ConsoleCommandEventLogger struct {
+	logger    *zap.Logger
+	formatter CommandEventFormatter
+}
+
+// NewConsoleCommandEventLogger constructs a console event logger backed by the provided zap logger.
+func NewConsoleCommandEventLogger(logger *zap.Logger) *ConsoleCommandEventLogger {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &ConsoleCommandEventLogger{logger: logger, formatter: CommandEventFormatter{}}
+}
+
+// CommandStarted implements execshell.CommandEventObserver by logging command start notifications.
+func (eventLogger *ConsoleCommandEventLogger) CommandStarted(command execshell.ShellCommand) {
+	if eventLogger == nil {
+		return
+	}
+	eventLogger.logger.Info(eventLogger.formatter.BuildStartedMessage(command))
+}
+
+// CommandCompleted implements execshell.CommandEventObserver by logging command completion notifications.
+func (eventLogger *ConsoleCommandEventLogger) CommandCompleted(command execshell.ShellCommand, result execshell.ExecutionResult) {
+	if eventLogger == nil {
+		return
+	}
+	if result.ExitCode == 0 {
+		eventLogger.logger.Info(eventLogger.formatter.BuildSuccessMessage(command))
+		return
+	}
+	eventLogger.logger.Warn(eventLogger.formatter.BuildFailureMessage(command, result))
+}
+
+// CommandExecutionFailed implements execshell.CommandEventObserver by logging unexpected execution failures.
+func (eventLogger *ConsoleCommandEventLogger) CommandExecutionFailed(command execshell.ShellCommand, failure error) {
+	if eventLogger == nil {
+		return
+	}
+	eventLogger.logger.Error(eventLogger.formatter.BuildExecutionFailureMessage(command, failure))
+}

--- a/internal/ui/command_events_test.go
+++ b/internal/ui/command_events_test.go
@@ -1,0 +1,91 @@
+package ui_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/ui"
+)
+
+const (
+	testCommandWorkingDirectoryConstant     = "/tmp/project"
+	testCommandArgumentConstant             = "--prune"
+	testCommandNameFieldExpectationConstant = "git --prune (in /tmp/project)"
+	testExecutionFailureReasonConstant      = "execution failed"
+	testStandardErrorMessageConstant        = "fatal: remote error"
+	testStartMessageExpectationConstant     = "Running " + testCommandNameFieldExpectationConstant
+	testSuccessMessageExpectationConstant   = "Completed " + testCommandNameFieldExpectationConstant
+	testFailureMessageExpectationConstant   = testCommandNameFieldExpectationConstant + " failed with exit code 1: " + testStandardErrorMessageConstant
+	testExecutionFailureMessageExpectation  = testCommandNameFieldExpectationConstant + " failed: " + testExecutionFailureReasonConstant
+)
+
+func TestConsoleCommandEventLoggerEmitsMessages(testInstance *testing.T) {
+	command := execshell.ShellCommand{
+		Name: execshell.CommandGit,
+		Details: execshell.CommandDetails{
+			Arguments:        []string{testCommandArgumentConstant},
+			WorkingDirectory: testCommandWorkingDirectoryConstant,
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		invoke          func(logger *ui.ConsoleCommandEventLogger)
+		expectedLevel   zapcore.Level
+		expectedMessage string
+	}{
+		{
+			name: "command_started",
+			invoke: func(logger *ui.ConsoleCommandEventLogger) {
+				logger.CommandStarted(command)
+			},
+			expectedLevel:   zapcore.InfoLevel,
+			expectedMessage: testStartMessageExpectationConstant,
+		},
+		{
+			name: "command_completed_success",
+			invoke: func(logger *ui.ConsoleCommandEventLogger) {
+				logger.CommandCompleted(command, execshell.ExecutionResult{ExitCode: 0})
+			},
+			expectedLevel:   zapcore.InfoLevel,
+			expectedMessage: testSuccessMessageExpectationConstant,
+		},
+		{
+			name: "command_completed_failure",
+			invoke: func(logger *ui.ConsoleCommandEventLogger) {
+				logger.CommandCompleted(command, execshell.ExecutionResult{ExitCode: 1, StandardError: testStandardErrorMessageConstant})
+			},
+			expectedLevel:   zapcore.WarnLevel,
+			expectedMessage: testFailureMessageExpectationConstant,
+		},
+		{
+			name: "command_execution_failure",
+			invoke: func(logger *ui.ConsoleCommandEventLogger) {
+				logger.CommandExecutionFailed(command, errors.New(testExecutionFailureReasonConstant))
+			},
+			expectedLevel:   zapcore.ErrorLevel,
+			expectedMessage: testExecutionFailureMessageExpectation,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			observerCore, observedLogs := observer.New(zapcore.DebugLevel)
+			consoleLogger := zap.New(observerCore)
+			eventLogger := ui.NewConsoleCommandEventLogger(consoleLogger)
+
+			testCase.invoke(eventLogger)
+
+			entries := observedLogs.All()
+			require.Len(testInstance, entries, 1)
+			require.Equal(testInstance, testCase.expectedLevel, entries[0].Level)
+			require.Equal(testInstance, testCase.expectedMessage, entries[0].Message)
+		})
+	}
+}

--- a/internal/ui/doc.go
+++ b/internal/ui/doc.go
@@ -1,0 +1,6 @@
+// Package ui provides helpers for formatting human-readable console output.
+//
+// The helpers translate internal events into concise messages so that command
+// execution feedback remains actionable for CLI users while detailed telemetry
+// continues to flow through structured loggers.
+package ui

--- a/tests/migrate_integration_test.go
+++ b/tests/migrate_integration_test.go
@@ -108,7 +108,7 @@ func TestMigrationIntegration(testInstance *testing.T) {
 
 			logger := zap.NewNop()
 			commandRunner := execshell.NewOSCommandRunner()
-			executor, creationError := execshell.NewShellExecutor(logger, commandRunner)
+			executor, creationError := execshell.NewShellExecutor(logger, commandRunner, nil)
 			require.NoError(subtest, creationError)
 			repositoryManager, managerError := gitrepo.NewRepositoryManager(executor)
 			require.NoError(subtest, managerError)

--- a/tests/pr_cleanup_integration_test.go
+++ b/tests/pr_cleanup_integration_test.go
@@ -92,7 +92,7 @@ func TestPullRequestCleanupIntegration(testInstance *testing.T) {
 
 	commandRunner := execshell.NewOSCommandRunner()
 	commandLogger := zap.NewNop()
-	shellExecutor, executorError := execshell.NewShellExecutor(commandLogger, commandRunner)
+	shellExecutor, executorError := execshell.NewShellExecutor(commandLogger, commandRunner, nil)
 	require.NoError(testInstance, executorError)
 
 	cleanupCommandBuilder := branches.CommandBuilder{


### PR DESCRIPTION
## Summary
- add a command event observer and console event logger so shell commands produce user friendly console output
- propagate the new observer through the CLI application, command builders, and shell executor
- refine logger creation to emit nicer console formatting and update tests and integration flows for the new behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d379a85c3c8327a59b02284f5d1ba2