### PR TITLE
Adjust execshell logging levels

### DIFF
--- a/internal/execshell/executor.go
+++ b/internal/execshell/executor.go
@@ -135,7 +135,7 @@ func (executor *ShellExecutor) Execute(executionContext context.Context, command
 	if executor.humanReadableLogging {
 		executor.logger.Info(executor.messageFormatter.BuildStartedMessage(command))
 	} else {
-		executor.logger.Debug(commandStartMessageConstant,
+		executor.logger.Info(commandStartMessageConstant,
 			zap.String(commandNameFieldNameConstant, string(command.Name)),
 			zap.Strings(commandArgumentsFieldNameConstant, command.Details.Arguments),
 			zap.String(workingDirectoryFieldNameConstant, command.Details.WorkingDirectory),
@@ -171,7 +171,7 @@ func (executor *ShellExecutor) Execute(executionContext context.Context, command
 	if executor.humanReadableLogging {
 		executor.logger.Info(executor.messageFormatter.BuildSuccessMessage(command))
 	} else {
-		executor.logger.Debug(commandSuccessMessageConstant,
+		executor.logger.Info(commandSuccessMessageConstant,
 			zap.String(commandNameFieldNameConstant, string(command.Name)),
 			zap.Int(exitCodeFieldNameConstant, executionResult.ExitCode),
 		)

--- a/internal/execshell/executor_test.go
+++ b/internal/execshell/executor_test.go
@@ -102,6 +102,7 @@ func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
 		runnerError      error
 		expectErrorType  any
 		expectedLogCount int
+		expectedLevels   []zapcore.Level
 	}{
 		{
 			name: testExecutionSuccessCaseNameConstant,
@@ -110,6 +111,7 @@ func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
 				ExitCode:       0,
 			},
 			expectedLogCount: 2,
+			expectedLevels:   []zapcore.Level{zap.InfoLevel, zap.InfoLevel},
 		},
 		{
 			name: testExecutionFailureCaseNameConstant,
@@ -119,12 +121,14 @@ func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
 			},
 			expectErrorType:  execshell.CommandFailedError{},
 			expectedLogCount: 2,
+			expectedLevels:   []zapcore.Level{zap.InfoLevel, zap.WarnLevel},
 		},
 		{
 			name:             testExecutionRunnerErrorCaseNameConstant,
 			runnerError:      errors.New(testRunnerFailureMessageConstant),
 			expectErrorType:  execshell.CommandExecutionError{},
 			expectedLogCount: 2,
+			expectedLevels:   []zapcore.Level{zap.InfoLevel, zap.ErrorLevel},
 		},
 	}
 
@@ -153,7 +157,11 @@ func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
 				require.Equal(testInstance, testCase.runnerResult.StandardOutput, executionResult.StandardOutput)
 			}
 
-			require.Len(testInstance, observerLogs.All(), testCase.expectedLogCount)
+			capturedLogs := observerLogs.All()
+			require.Len(testInstance, capturedLogs, testCase.expectedLogCount)
+			for logIndex := range capturedLogs {
+				require.Equal(testInstance, testCase.expectedLevels[logIndex], capturedLogs[logIndex].Level)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- raise structured command start and success logging to info level
- expand executor behavior tests to assert info-level structured logs

## Testing
- go test ./internal/execshell

------
https://chatgpt.com/codex/tasks/task_e_68d5a3aed26c83278202eaa07cf91e3e