### PR TITLE
Refactor configuration hierarchy to nest common and tools settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Global flags configure logging and optional configuration files:
 - `--log-level <debug|info|warn|error>` – override the configured log level.
 - `--log-format <structured|console>` – switch between JSON and human-readable logs.
 
-Configuration keys mirror the flags (`log_level`, `log_format`) and can also be provided via environment variables prefixed with
-`GITSCRIPTS_` (for example, `GITSCRIPTS_LOG_LEVEL=error`).
+Configuration keys mirror the flags (`common.log_level`, `common.log_format`) and can also be provided via environment variables prefixed with
+`GITSCRIPTS_` (for example, `GITSCRIPTS_COMMON_LOG_LEVEL=error`).
 
 ## Command catalog
 
@@ -142,15 +142,17 @@ Persist defaults in a configuration file to avoid long flag lists:
 
 ```yaml
 # packages.yaml
-log_level: info
-log_format: structured
-packages:
-  purge:
-    owner: my-org
-    package: my-image
-    owner_type: org
-    token_source: env:GITHUB_PACKAGES_TOKEN
-    page_size: 50
+common:
+  log_level: info
+  log_format: structured
+tools:
+  packages:
+    purge:
+      owner: my-org
+      package: my-image
+      owner_type: org
+      token_source: env:GITHUB_PACKAGES_TOKEN
+      page_size: 50
 ```
 
 ```bash

--- a/internal/packages/configuration.go
+++ b/internal/packages/configuration.go
@@ -1,18 +1,19 @@
 package packages
 
 const (
-	configurationKeyPackagesConstant   = "packages"
-	purgeConfigurationKeyConstant      = configurationKeyPackagesConstant + ".purge"
-	purgeOwnerKeyConstant              = purgeConfigurationKeyConstant + ".owner"
-	purgePackageNameKeyConstant        = purgeConfigurationKeyConstant + ".package"
-	purgeOwnerTypeKeyConstant          = purgeConfigurationKeyConstant + ".owner_type"
-	purgeTokenSourceKeyConstant        = purgeConfigurationKeyConstant + ".token_source"
-	purgeDryRunKeyConstant             = purgeConfigurationKeyConstant + ".dry_run"
-	purgeServiceBaseURLKeyConstant     = purgeConfigurationKeyConstant + ".service_base_url"
-	purgePageSizeKeyConstant           = purgeConfigurationKeyConstant + ".page_size"
-	defaultTokenSourceValueConstant    = "env:GITHUB_PACKAGES_TOKEN"
-	defaultServiceBaseURLValueConstant = ""
-	defaultPageSizeValueConstant       = 0
+	toolsConfigurationRootKeyConstant    = "tools"
+	packagesConfigurationRootKeyConstant = toolsConfigurationRootKeyConstant + ".packages"
+	purgeConfigurationKeyConstant        = packagesConfigurationRootKeyConstant + ".purge"
+	purgeOwnerKeyConstant                = purgeConfigurationKeyConstant + ".owner"
+	purgePackageNameKeyConstant          = purgeConfigurationKeyConstant + ".package"
+	purgeOwnerTypeKeyConstant            = purgeConfigurationKeyConstant + ".owner_type"
+	purgeTokenSourceKeyConstant          = purgeConfigurationKeyConstant + ".token_source"
+	purgeDryRunKeyConstant               = purgeConfigurationKeyConstant + ".dry_run"
+	purgeServiceBaseURLKeyConstant       = purgeConfigurationKeyConstant + ".service_base_url"
+	purgePageSizeKeyConstant             = purgeConfigurationKeyConstant + ".page_size"
+	defaultTokenSourceValueConstant      = "env:GITHUB_PACKAGES_TOKEN"
+	defaultServiceBaseURLValueConstant   = ""
+	defaultPageSizeValueConstant         = 0
 )
 
 // Configuration aggregates settings for packages commands.

--- a/tests/cli_integration_test.go
+++ b/tests/cli_integration_test.go
@@ -17,9 +17,9 @@ import (
 const (
 	integrationInfoMessageConstant                     = "\"msg\":\"git_scripts CLI executed\""
 	integrationDebugMessageConstant                    = "\"msg\":\"git_scripts CLI diagnostics\""
-	integrationLogLevelEnvKeyConstant                  = "GITSCRIPTS_LOG_LEVEL"
+	integrationLogLevelEnvKeyConstant                  = "GITSCRIPTS_COMMON_LOG_LEVEL"
 	integrationConfigFileNameConstant                  = "config.yaml"
-	integrationConfigTemplateConstant                  = "log_level: %s\n"
+	integrationConfigTemplateConstant                  = "common:\n  log_level: %s\n"
 	integrationDefaultCaseNameConstant                 = "default_info"
 	integrationConfigCaseNameConstant                  = "config_debug"
 	integrationEnvironmentCaseNameConstant             = "environment_error"

--- a/tests/packages_integration_test.go
+++ b/tests/packages_integration_test.go
@@ -23,7 +23,7 @@ const (
 	packagesIntegrationTokenReferenceConstant           = "env:PACKAGES_TOKEN"
 	packagesIntegrationTokenValueConstant               = "packages-token-value"
 	packagesIntegrationConfigFileNameConstant           = "config.yaml"
-	packagesIntegrationConfigTemplateConstant           = "log_level: error\npackages:\n  purge:\n    owner: %s\n    package: %s\n    owner_type: %s\n    token_source: %s\n    dry_run: %t\n    service_base_url: %s\n    page_size: %d\n"
+	packagesIntegrationConfigTemplateConstant           = "common:\n  log_level: error\ntools:\n  packages:\n    purge:\n      owner: %s\n      package: %s\n      owner_type: %s\n      token_source: %s\n      dry_run: %t\n      service_base_url: %s\n      page_size: %d\n"
 	packagesIntegrationSubtestNameTemplateConstant      = "%d_%s"
 	packagesIntegrationRunSubcommandConstant            = "run"
 	packagesIntegrationModulePathConstant               = "."


### PR DESCRIPTION
## Summary
- restructure the CLI application configuration into common and tools sections and update configuration defaults
- root package defaults under tools.packages and ensure the packages command builder reads from the nested configuration
- refresh documentation, fixtures, and tests to align with the nested configuration hierarchy

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5b05b3ca8832781bc781db06b24b2