### PR TITLE
Fix configuration helpers and integration constants

### DIFF
--- a/cmd/cli/repos/configuration.go
+++ b/cmd/cli/repos/configuration.go
@@ -1,0 +1,90 @@
+package repos
+
+import "strings"
+
+const (
+	remotesConfigurationKeyConstant      = "remotes"
+	protocolConfigurationKeyConstant     = "protocol"
+	configurationDryRunKeyConstant       = "dry_run"
+	configurationAssumeYesKeyConstant    = "assume_yes"
+	configurationRootsKeyConstant        = "roots"
+	protocolConfigurationFromKeyConstant = "from"
+	protocolConfigurationToKeyConstant   = "to"
+)
+
+// ToolsConfiguration captures repository command configuration sections.
+type ToolsConfiguration struct {
+	Remotes  RemotesConfiguration  `mapstructure:"remotes"`
+	Protocol ProtocolConfiguration `mapstructure:"protocol"`
+}
+
+// RemotesConfiguration describes configuration values for repo-remote-update.
+type RemotesConfiguration struct {
+	DryRun          bool     `mapstructure:"dry_run"`
+	AssumeYes       bool     `mapstructure:"assume_yes"`
+	RepositoryRoots []string `mapstructure:"roots"`
+}
+
+// ProtocolConfiguration describes configuration values for protocol-convert.
+type ProtocolConfiguration struct {
+	DryRun          bool     `mapstructure:"dry_run"`
+	AssumeYes       bool     `mapstructure:"assume_yes"`
+	RepositoryRoots []string `mapstructure:"roots"`
+	FromProtocol    string   `mapstructure:"from"`
+	ToProtocol      string   `mapstructure:"to"`
+}
+
+// DefaultToolsConfiguration returns baseline configuration values for repository commands.
+func DefaultToolsConfiguration() ToolsConfiguration {
+	return ToolsConfiguration{
+		Remotes: RemotesConfiguration{
+			DryRun:          false,
+			AssumeYes:       false,
+			RepositoryRoots: []string{defaultRepositoryRootConstant},
+		},
+		Protocol: ProtocolConfiguration{
+			DryRun:          false,
+			AssumeYes:       false,
+			RepositoryRoots: []string{defaultRepositoryRootConstant},
+			FromProtocol:    "",
+			ToProtocol:      "",
+		},
+	}
+}
+
+// DefaultConfigurationValues produces Viper defaults for repository commands.
+func DefaultConfigurationValues(rootKey string) map[string]any {
+	defaults := DefaultToolsConfiguration()
+	return map[string]any{
+		rootKey + "." + remotesConfigurationKeyConstant + "." + configurationDryRunKeyConstant:        defaults.Remotes.DryRun,
+		rootKey + "." + remotesConfigurationKeyConstant + "." + configurationAssumeYesKeyConstant:     defaults.Remotes.AssumeYes,
+		rootKey + "." + remotesConfigurationKeyConstant + "." + configurationRootsKeyConstant:         defaults.Remotes.RepositoryRoots,
+		rootKey + "." + protocolConfigurationKeyConstant + "." + configurationDryRunKeyConstant:       defaults.Protocol.DryRun,
+		rootKey + "." + protocolConfigurationKeyConstant + "." + configurationAssumeYesKeyConstant:    defaults.Protocol.AssumeYes,
+		rootKey + "." + protocolConfigurationKeyConstant + "." + configurationRootsKeyConstant:        defaults.Protocol.RepositoryRoots,
+		rootKey + "." + protocolConfigurationKeyConstant + "." + protocolConfigurationFromKeyConstant: defaults.Protocol.FromProtocol,
+		rootKey + "." + protocolConfigurationKeyConstant + "." + protocolConfigurationToKeyConstant:   defaults.Protocol.ToProtocol,
+	}
+}
+
+// sanitize normalizes repository configuration values.
+func (configuration RemotesConfiguration) sanitize() RemotesConfiguration {
+	sanitized := configuration
+	sanitized.RepositoryRoots = trimRoots(configuration.RepositoryRoots)
+	if len(sanitized.RepositoryRoots) == 0 {
+		sanitized.RepositoryRoots = append([]string{}, defaultRepositoryRootConstant)
+	}
+	return sanitized
+}
+
+// sanitize normalizes protocol configuration values.
+func (configuration ProtocolConfiguration) sanitize() ProtocolConfiguration {
+	sanitized := configuration
+	sanitized.RepositoryRoots = trimRoots(configuration.RepositoryRoots)
+	if len(sanitized.RepositoryRoots) == 0 {
+		sanitized.RepositoryRoots = append([]string{}, defaultRepositoryRootConstant)
+	}
+	sanitized.FromProtocol = strings.TrimSpace(configuration.FromProtocol)
+	sanitized.ToProtocol = strings.TrimSpace(configuration.ToProtocol)
+	return sanitized
+}

--- a/cmd/cli/repos/helpers.go
+++ b/cmd/cli/repos/helpers.go
@@ -20,19 +20,30 @@ type LoggerProvider func() *zap.Logger
 // PrompterFactory creates confirmation prompters scoped to a Cobra command.
 type PrompterFactory func(*cobra.Command) shared.ConfirmationPrompter
 
-func determineRepositoryRoots(arguments []string) []string {
-	roots := make([]string, 0, len(arguments))
-	for _, argument := range arguments {
-		trimmed := strings.TrimSpace(argument)
-		if len(trimmed) == 0 {
+func determineRepositoryRoots(arguments []string, configuredRoots []string) []string {
+	roots := trimRoots(arguments)
+	if len(roots) > 0 {
+		return roots
+	}
+
+	configured := trimRoots(configuredRoots)
+	if len(configured) > 0 {
+		return configured
+	}
+
+	return []string{defaultRepositoryRootConstant}
+}
+
+func trimRoots(raw []string) []string {
+	trimmed := make([]string, 0, len(raw))
+	for _, argument := range raw {
+		candidate := strings.TrimSpace(argument)
+		if len(candidate) == 0 {
 			continue
 		}
-		roots = append(roots, trimmed)
+		trimmed = append(trimmed, candidate)
 	}
-	if len(roots) == 0 {
-		return []string{defaultRepositoryRootConstant}
-	}
-	return roots
+	return trimmed
 }
 
 func resolveLogger(provider LoggerProvider) *zap.Logger {

--- a/cmd/cli/repos/protocol_test.go
+++ b/cmd/cli/repos/protocol_test.go
@@ -1,0 +1,150 @@
+package repos_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	repos "github.com/temirov/git_scripts/cmd/cli/repos"
+	"github.com/temirov/git_scripts/internal/githubcli"
+	"github.com/temirov/git_scripts/internal/repos/shared"
+)
+
+const (
+	protocolFromFlagConstant       = "--from"
+	protocolToFlagConstant         = "--to"
+	protocolYesFlagConstant        = "--yes"
+	protocolDryRunFlagConstant     = "--dry-run"
+	protocolConfiguredRootConstant = "/tmp/protocol-config-root"
+	protocolSSHRemoteURL           = "ssh://git@github.com/origin/example.git"
+	protocolHTTPSRemoteURL         = "https://github.com/origin/example.git"
+)
+
+func TestProtocolCommandConfigurationPrecedence(testInstance *testing.T) {
+	testCases := []struct {
+		name                    string
+		configuration           repos.ProtocolConfiguration
+		arguments               []string
+		initialRemoteURL        string
+		expectedRoots           []string
+		expectRemoteUpdates     int
+		expectPromptInvocations int
+	}{
+		{
+			name: "configuration_supplies_protocols",
+			configuration: repos.ProtocolConfiguration{
+				DryRun:          true,
+				AssumeYes:       false,
+				RepositoryRoots: []string{protocolConfiguredRootConstant},
+				FromProtocol:    string(shared.RemoteProtocolHTTPS),
+				ToProtocol:      string(shared.RemoteProtocolSSH),
+			},
+			arguments:               []string{},
+			initialRemoteURL:        protocolHTTPSRemoteURL,
+			expectedRoots:           []string{protocolConfiguredRootConstant},
+			expectRemoteUpdates:     0,
+			expectPromptInvocations: 0,
+		},
+		{
+			name: "flags_override_configuration",
+			configuration: repos.ProtocolConfiguration{
+				DryRun:          false,
+				AssumeYes:       false,
+				RepositoryRoots: []string{protocolConfiguredRootConstant},
+				FromProtocol:    string(shared.RemoteProtocolSSH),
+				ToProtocol:      string(shared.RemoteProtocolHTTPS),
+			},
+			arguments: []string{
+				protocolFromFlagConstant,
+				string(shared.RemoteProtocolHTTPS),
+				protocolToFlagConstant,
+				string(shared.RemoteProtocolSSH),
+				protocolYesFlagConstant,
+				protocolDryRunFlagConstant,
+				remotesCLIRepositoryRootConstant,
+			},
+			initialRemoteURL:        protocolHTTPSRemoteURL,
+			expectedRoots:           []string{remotesCLIRepositoryRootConstant},
+			expectRemoteUpdates:     0,
+			expectPromptInvocations: 0,
+		},
+		{
+			name: "configuration_triggers_remote_update",
+			configuration: repos.ProtocolConfiguration{
+				DryRun:          false,
+				AssumeYes:       true,
+				RepositoryRoots: []string{protocolConfiguredRootConstant},
+				FromProtocol:    string(shared.RemoteProtocolHTTPS),
+				ToProtocol:      string(shared.RemoteProtocolSSH),
+			},
+			arguments:               []string{},
+			initialRemoteURL:        protocolHTTPSRemoteURL,
+			expectedRoots:           []string{protocolConfiguredRootConstant},
+			expectRemoteUpdates:     1,
+			expectPromptInvocations: 0,
+		},
+	}
+
+	for testCaseIndex := range testCases {
+		testCase := testCases[testCaseIndex]
+		testInstance.Run(testCase.name, func(subtest *testing.T) {
+			discoverer := &fakeRepositoryDiscoverer{repositories: []string{remotesDiscoveredRepository}}
+			executor := &fakeGitExecutor{}
+			manager := &fakeGitRepositoryManager{remoteURL: testCase.initialRemoteURL, currentBranch: remotesMetadataDefaultBranch}
+			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: remotesCanonicalRepository, DefaultBranch: remotesMetadataDefaultBranch}}
+			prompter := &recordingPrompter{confirmResult: true}
+
+			builder := repos.ProtocolCommandBuilder{
+				LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+				Discoverer:     discoverer,
+				GitExecutor:    executor,
+				GitManager:     manager,
+				GitHubResolver: resolver,
+				PrompterFactory: func(*cobra.Command) shared.ConfirmationPrompter {
+					return prompter
+				},
+				ConfigurationProvider: func() repos.ProtocolConfiguration {
+					return testCase.configuration
+				},
+			}
+
+			command, buildError := builder.Build()
+			require.NoError(subtest, buildError)
+
+			command.SetContext(context.Background())
+			command.SetArgs(testCase.arguments)
+
+			executionError := command.Execute()
+			if testCase.expectRemoteUpdates == 0 {
+				require.NoError(subtest, executionError)
+			} else {
+				require.NoError(subtest, executionError)
+			}
+
+			require.Equal(subtest, testCase.expectedRoots, discoverer.receivedRoots)
+			require.Equal(subtest, testCase.expectPromptInvocations, prompter.calls)
+			require.Equal(subtest, testCase.expectRemoteUpdates, len(manager.setCalls))
+			if testCase.expectRemoteUpdates > 0 {
+				require.NotEmpty(subtest, manager.setCalls)
+				require.Equal(subtest, string(shared.RemoteProtocolSSH), detectProtocol(manager.setCalls[len(manager.setCalls)-1].remoteURL))
+			}
+		})
+	}
+}
+
+func detectProtocol(remoteURL string) string {
+	switch {
+	case len(remoteURL) == 0:
+		return ""
+	case strings.HasPrefix(remoteURL, shared.SSHProtocolURLPrefixConstant):
+		return string(shared.RemoteProtocolSSH)
+	case strings.HasPrefix(remoteURL, shared.HTTPSProtocolURLPrefixConstant):
+		return string(shared.RemoteProtocolHTTPS)
+	default:
+		return ""
+	}
+}

--- a/cmd/cli/repos/remotes_test.go
+++ b/cmd/cli/repos/remotes_test.go
@@ -1,0 +1,182 @@
+package repos_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	repos "github.com/temirov/git_scripts/cmd/cli/repos"
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
+	"github.com/temirov/git_scripts/internal/repos/shared"
+)
+
+const (
+	remotesAssumeYesFlagConstant     = "--yes"
+	remotesDryRunFlagConstant        = "--dry-run"
+	remotesConfiguredRootConstant    = "/tmp/remotes-config-root"
+	remotesCLIRepositoryRootConstant = "/tmp/remotes-cli-root"
+	remotesDiscoveredRepository      = "/tmp/remotes-repo"
+	remotesOriginURLConstant         = "https://github.com/origin/example.git"
+	remotesCanonicalRepository       = "canonical/example"
+	remotesMetadataDefaultBranch     = "main"
+)
+
+func TestRemotesCommandConfigurationPrecedence(testInstance *testing.T) {
+	testCases := []struct {
+		name                    string
+		configuration           repos.RemotesConfiguration
+		arguments               []string
+		expectedRoots           []string
+		expectRemoteUpdates     int
+		expectPromptInvocations int
+	}{
+		{
+			name: "configuration_enables_dry_run",
+			configuration: repos.RemotesConfiguration{
+				DryRun:          true,
+				AssumeYes:       false,
+				RepositoryRoots: []string{remotesConfiguredRootConstant},
+			},
+			arguments:               []string{},
+			expectedRoots:           []string{remotesConfiguredRootConstant},
+			expectRemoteUpdates:     0,
+			expectPromptInvocations: 0,
+		},
+		{
+			name: "flags_override_configuration",
+			configuration: repos.RemotesConfiguration{
+				DryRun:          false,
+				AssumeYes:       false,
+				RepositoryRoots: []string{remotesConfiguredRootConstant},
+			},
+			arguments: []string{
+				remotesAssumeYesFlagConstant,
+				remotesDryRunFlagConstant,
+				remotesCLIRepositoryRootConstant,
+			},
+			expectedRoots:           []string{remotesCLIRepositoryRootConstant},
+			expectRemoteUpdates:     0,
+			expectPromptInvocations: 0,
+		},
+		{
+			name:                    "defaults_apply_without_configuration",
+			configuration:           repos.RemotesConfiguration{},
+			arguments:               []string{},
+			expectedRoots:           []string{"."},
+			expectRemoteUpdates:     1,
+			expectPromptInvocations: 1,
+		},
+	}
+
+	for testCaseIndex := range testCases {
+		testCase := testCases[testCaseIndex]
+		testInstance.Run(testCase.name, func(subtest *testing.T) {
+			discoverer := &fakeRepositoryDiscoverer{repositories: []string{remotesDiscoveredRepository}}
+			executor := &fakeGitExecutor{}
+			manager := &fakeGitRepositoryManager{remoteURL: remotesOriginURLConstant, currentBranch: remotesMetadataDefaultBranch}
+			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: remotesCanonicalRepository, DefaultBranch: remotesMetadataDefaultBranch}}
+			prompter := &recordingPrompter{confirmResult: true}
+
+			builder := repos.RemotesCommandBuilder{
+				LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+				Discoverer:     discoverer,
+				GitExecutor:    executor,
+				GitManager:     manager,
+				GitHubResolver: resolver,
+				PrompterFactory: func(*cobra.Command) shared.ConfirmationPrompter {
+					return prompter
+				},
+				ConfigurationProvider: func() repos.RemotesConfiguration {
+					return testCase.configuration
+				},
+			}
+
+			command, buildError := builder.Build()
+			require.NoError(subtest, buildError)
+
+			command.SetContext(context.Background())
+			command.SetArgs(testCase.arguments)
+
+			executionError := command.Execute()
+			require.NoError(subtest, executionError)
+
+			require.Equal(subtest, testCase.expectedRoots, discoverer.receivedRoots)
+			require.Equal(subtest, testCase.expectPromptInvocations, prompter.calls)
+			require.Equal(subtest, testCase.expectRemoteUpdates, len(manager.setCalls))
+		})
+	}
+}
+
+type fakeRepositoryDiscoverer struct {
+	repositories  []string
+	receivedRoots []string
+}
+
+func (discoverer *fakeRepositoryDiscoverer) DiscoverRepositories(roots []string) ([]string, error) {
+	discoverer.receivedRoots = append([]string{}, roots...)
+	return append([]string{}, discoverer.repositories...), nil
+}
+
+type fakeGitExecutor struct{}
+
+func (executor *fakeGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	if len(details.Arguments) > 0 && details.Arguments[0] == "rev-parse" {
+		return execshell.ExecutionResult{StandardOutput: "true\n"}, nil
+	}
+	return execshell.ExecutionResult{StandardOutput: ""}, nil
+}
+
+func (executor *fakeGitExecutor) ExecuteGitHubCLI(_ context.Context, _ execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{StandardOutput: ""}, nil
+}
+
+type fakeGitRepositoryManager struct {
+	remoteURL     string
+	currentBranch string
+	setCalls      []remoteUpdateCall
+}
+
+type remoteUpdateCall struct {
+	repositoryPath string
+	remoteURL      string
+}
+
+func (manager *fakeGitRepositoryManager) CheckCleanWorktree(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func (manager *fakeGitRepositoryManager) GetCurrentBranch(context.Context, string) (string, error) {
+	return manager.currentBranch, nil
+}
+
+func (manager *fakeGitRepositoryManager) GetRemoteURL(context.Context, string, string) (string, error) {
+	return manager.remoteURL, nil
+}
+
+func (manager *fakeGitRepositoryManager) SetRemoteURL(_ context.Context, repositoryPath string, _ string, remoteURL string) error {
+	manager.setCalls = append(manager.setCalls, remoteUpdateCall{repositoryPath: repositoryPath, remoteURL: remoteURL})
+	manager.remoteURL = remoteURL
+	return nil
+}
+
+type fakeGitHubResolver struct {
+	metadata githubcli.RepositoryMetadata
+}
+
+func (resolver *fakeGitHubResolver) ResolveRepoMetadata(context.Context, string) (githubcli.RepositoryMetadata, error) {
+	return resolver.metadata, nil
+}
+
+type recordingPrompter struct {
+	confirmResult bool
+	calls         int
+}
+
+func (prompter *recordingPrompter) Confirm(string) (bool, error) {
+	prompter.calls++
+	return prompter.confirmResult, nil
+}

--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -57,7 +57,7 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 	assumeYes, _ := command.Flags().GetBool(renameAssumeYesFlagName)
 	requireClean, _ := command.Flags().GetBool(renameRequireCleanFlagName)
 
-	roots := determineRepositoryRoots(arguments)
+        roots := determineRepositoryRoots(arguments, nil)
 
 	logger := resolveLogger(builder.LoggerProvider)
 	humanReadableLogging := false

--- a/cmd/cli/workflow/configuration.go
+++ b/cmd/cli/workflow/configuration.go
@@ -1,0 +1,57 @@
+package workflow
+
+import "strings"
+
+const (
+	workflowConfigurationRootsKeyConstant     = "roots"
+	workflowConfigurationDryRunKeyConstant    = "dry_run"
+	workflowConfigurationAssumeYesKeyConstant = "assume_yes"
+)
+
+// CommandConfiguration captures configuration values for workflow-run.
+type CommandConfiguration struct {
+	Roots     []string `mapstructure:"roots"`
+	DryRun    bool     `mapstructure:"dry_run"`
+	AssumeYes bool     `mapstructure:"assume_yes"`
+}
+
+// DefaultCommandConfiguration provides default workflow command settings.
+func DefaultCommandConfiguration() CommandConfiguration {
+	return CommandConfiguration{
+		Roots:     []string{defaultWorkflowRootConstant},
+		DryRun:    false,
+		AssumeYes: false,
+	}
+}
+
+// DefaultConfigurationValues returns configuration defaults keyed for Viper.
+func DefaultConfigurationValues(rootKey string) map[string]any {
+	defaults := DefaultCommandConfiguration()
+	return map[string]any{
+		rootKey + "." + workflowConfigurationRootsKeyConstant:     defaults.Roots,
+		rootKey + "." + workflowConfigurationDryRunKeyConstant:    defaults.DryRun,
+		rootKey + "." + workflowConfigurationAssumeYesKeyConstant: defaults.AssumeYes,
+	}
+}
+
+// sanitize normalizes configuration values.
+func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+	sanitized := configuration
+	sanitized.Roots = sanitizeRoots(configuration.Roots)
+	if len(sanitized.Roots) == 0 {
+		sanitized.Roots = append([]string{}, defaultWorkflowRootConstant)
+	}
+	return sanitized
+}
+
+func sanitizeRoots(raw []string) []string {
+	trimmed := make([]string, 0, len(raw))
+	for _, candidate := range raw {
+		value := strings.TrimSpace(candidate)
+		if len(value) == 0 {
+			continue
+		}
+		trimmed = append(trimmed, value)
+	}
+	return trimmed
+}

--- a/cmd/cli/workflow/run_test.go
+++ b/cmd/cli/workflow/run_test.go
@@ -1,0 +1,133 @@
+package workflow_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	workflowcmd "github.com/temirov/git_scripts/cmd/cli/workflow"
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	workflowConfigFileNameConstant = "workflow.yaml"
+	workflowConfigContentConstant  = "steps:\n  - operation: audit-report\n"
+	workflowConfiguredRootConstant = "/tmp/workflow-config-root"
+	workflowCliRootConstant        = "/tmp/workflow-cli-root"
+	workflowPlanMessageSnippet     = "WORKFLOW-PLAN: audit report"
+	workflowCSVHeaderSnippet       = "final_github_repo,folder_name"
+	workflowRootsFlagConstant      = "--roots"
+	workflowDryRunFlagConstant     = "--dry-run"
+)
+
+func TestWorkflowCommandConfigurationPrecedence(testInstance *testing.T) {
+	testCases := []struct {
+		name              string
+		configuration     workflowcmd.CommandConfiguration
+		additionalArgs    []string
+		expectedRoots     []string
+		expectPlanMessage bool
+	}{
+		{
+			name: "configuration_applies_without_flags",
+			configuration: workflowcmd.CommandConfiguration{
+				Roots:  []string{workflowConfiguredRootConstant},
+				DryRun: true,
+			},
+			additionalArgs:    []string{},
+			expectedRoots:     []string{workflowConfiguredRootConstant},
+			expectPlanMessage: true,
+		},
+		{
+			name: "flags_override_configuration",
+			configuration: workflowcmd.CommandConfiguration{
+				Roots:  []string{workflowConfiguredRootConstant},
+				DryRun: false,
+			},
+			additionalArgs: []string{
+				workflowRootsFlagConstant,
+				workflowCliRootConstant,
+				workflowDryRunFlagConstant,
+			},
+			expectedRoots:     []string{workflowCliRootConstant},
+			expectPlanMessage: true,
+		},
+		{
+			name:              "defaults_fill_when_configuration_empty",
+			configuration:     workflowcmd.CommandConfiguration{},
+			additionalArgs:    []string{},
+			expectedRoots:     []string{"."},
+			expectPlanMessage: false,
+		},
+	}
+
+	for testCaseIndex := range testCases {
+		testCase := testCases[testCaseIndex]
+		testInstance.Run(testCase.name, func(subtest *testing.T) {
+			tempDirectory := subtest.TempDir()
+			configPath := filepath.Join(tempDirectory, workflowConfigFileNameConstant)
+			writeError := os.WriteFile(configPath, []byte(workflowConfigContentConstant), 0o644)
+			require.NoError(subtest, writeError)
+
+			discoverer := &fakeWorkflowDiscoverer{}
+			executor := &fakeWorkflowGitExecutor{}
+
+			builder := workflowcmd.CommandBuilder{
+				LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+				Discoverer:     discoverer,
+				GitExecutor:    executor,
+				ConfigurationProvider: func() workflowcmd.CommandConfiguration {
+					return testCase.configuration
+				},
+			}
+
+			command, buildError := builder.Build()
+			require.NoError(subtest, buildError)
+
+			var outputBuffer bytes.Buffer
+			var errorBuffer bytes.Buffer
+			command.SetOut(&outputBuffer)
+			command.SetErr(&errorBuffer)
+			command.SetContext(context.Background())
+
+			arguments := append([]string{configPath}, testCase.additionalArgs...)
+			command.SetArgs(arguments)
+
+			executionError := command.Execute()
+			require.NoError(subtest, executionError)
+
+			require.Equal(subtest, testCase.expectedRoots, discoverer.receivedRoots)
+
+			outputText := outputBuffer.String()
+			if testCase.expectPlanMessage {
+				require.Contains(subtest, outputText, workflowPlanMessageSnippet)
+			} else {
+				require.Contains(subtest, outputText, workflowCSVHeaderSnippet)
+			}
+		})
+	}
+}
+
+type fakeWorkflowDiscoverer struct {
+	receivedRoots []string
+}
+
+func (discoverer *fakeWorkflowDiscoverer) DiscoverRepositories(roots []string) ([]string, error) {
+	discoverer.receivedRoots = append([]string{}, roots...)
+	return []string{}, nil
+}
+
+type fakeWorkflowGitExecutor struct{}
+
+func (executor *fakeWorkflowGitExecutor) ExecuteGit(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{StandardOutput: ""}, nil
+}
+
+func (executor *fakeWorkflowGitExecutor) ExecuteGitHubCLI(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{StandardOutput: ""}, nil
+}

--- a/internal/branches/configuration.go
+++ b/internal/branches/configuration.go
@@ -1,0 +1,73 @@
+package branches
+
+import "strings"
+
+const (
+	branchCleanupConfigurationRemoteKeyConstant = "remote"
+	branchCleanupConfigurationLimitKeyConstant  = "limit"
+	branchCleanupConfigurationDryRunKeyConstant = "dry_run"
+	branchCleanupConfigurationRootsKeyConstant  = "roots"
+	defaultRepositoryRootConstant               = "."
+)
+
+// CommandConfiguration captures configuration values for the branch cleanup command.
+type CommandConfiguration struct {
+	RemoteName       string   `mapstructure:"remote"`
+	PullRequestLimit int      `mapstructure:"limit"`
+	DryRun           bool     `mapstructure:"dry_run"`
+	RepositoryRoots  []string `mapstructure:"roots"`
+}
+
+// DefaultCommandConfiguration provides baseline configuration values for branch cleanup.
+func DefaultCommandConfiguration() CommandConfiguration {
+	return CommandConfiguration{
+		RemoteName:       defaultRemoteNameConstant,
+		PullRequestLimit: defaultPullRequestLimitConstant,
+		DryRun:           false,
+		RepositoryRoots:  []string{defaultRepositoryRootConstant},
+	}
+}
+
+// DefaultConfigurationValues returns Viper-ready defaults for branch cleanup settings.
+func DefaultConfigurationValues(rootKey string) map[string]any {
+	defaults := DefaultCommandConfiguration()
+
+	return map[string]any{
+		rootKey + "." + branchCleanupConfigurationRemoteKeyConstant: defaults.RemoteName,
+		rootKey + "." + branchCleanupConfigurationLimitKeyConstant:  defaults.PullRequestLimit,
+		rootKey + "." + branchCleanupConfigurationDryRunKeyConstant: defaults.DryRun,
+		rootKey + "." + branchCleanupConfigurationRootsKeyConstant:  defaults.RepositoryRoots,
+	}
+}
+
+// sanitize populates zero values with defaults and trims whitespace.
+func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+	sanitized := configuration
+
+	if len(strings.TrimSpace(configuration.RemoteName)) == 0 {
+		sanitized.RemoteName = defaultRemoteNameConstant
+	}
+
+	if configuration.PullRequestLimit <= 0 {
+		sanitized.PullRequestLimit = defaultPullRequestLimitConstant
+	}
+
+	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
+	if len(sanitized.RepositoryRoots) == 0 {
+		sanitized.RepositoryRoots = append([]string{}, defaultRepositoryRootConstant)
+	}
+
+	return sanitized
+}
+
+func sanitizeRoots(raw []string) []string {
+	sanitized := make([]string, 0, len(raw))
+	for _, candidate := range raw {
+		trimmed := strings.TrimSpace(candidate)
+		if len(trimmed) == 0 {
+			continue
+		}
+		sanitized = append(sanitized, trimmed)
+	}
+	return sanitized
+}


### PR DESCRIPTION
## Summary
- reuse the shared root trimming helper in the repos configuration sanitization to eliminate duplicate definitions
- rename the workflow configuration variable to avoid clashing with the workflow package configuration type
- restore the repos integration constants and adjust protocol tests to assert protocol detection by prefix so config-driven cases succeed

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5ceb9175c8327b1eb1185a8764667