### PR TITLE
Introduce audit-run command with configuration-backed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Configuration keys mirror the flags (`common.log_level`, `common.log_format`) an
 ### Audit reports
 
 ```shell
-go run . audit --audit ~/Development
+go run . audit-run --root ~/Development
 ```
 
-`audit --audit` scans each repository beneath the provided roots (defaults to the current directory) and writes a CSV summary to
+`audit-run` scans each repository beneath the provided roots (defaults to the current directory or configured roots) and writes a CSV summary to
 stdout. Add `--debug` to log discovery progress and inspection diagnostics.
 
 ### Repository maintenance commands

--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -55,6 +55,7 @@ const (
 	branchCleanupConfigurationKeyConstant   = toolsConfigurationKeyConstant + ".branch_cleanup"
 	reposConfigurationKeyConstant           = toolsConfigurationKeyConstant + ".repos"
 	workflowConfigurationKeyConstant        = toolsConfigurationKeyConstant + ".workflow"
+	auditConfigurationKeyConstant           = toolsConfigurationKeyConstant + ".audit"
 )
 
 // ApplicationConfiguration describes the persisted configuration for the CLI entrypoint.
@@ -71,6 +72,7 @@ type ApplicationCommonConfiguration struct {
 
 // ApplicationToolsConfiguration holds configuration for CLI subcommands grouped by tool family.
 type ApplicationToolsConfiguration struct {
+	Audit         audit.CommandConfiguration       `mapstructure:"audit"`
 	Packages      packages.Configuration           `mapstructure:"packages"`
 	BranchCleanup branches.CommandConfiguration    `mapstructure:"branch_cleanup"`
 	Repos         repos.ToolsConfiguration         `mapstructure:"repos"`
@@ -131,6 +133,9 @@ func NewApplication() *Application {
 			return application.logger
 		},
 		HumanReadableLoggingProvider: application.humanReadableLoggingEnabled,
+		ConfigurationProvider: func() audit.CommandConfiguration {
+			return application.configuration.Tools.Audit
+		},
 	}
 	auditCommand, auditBuildError := auditBuilder.Build()
 	if auditBuildError == nil {
@@ -254,6 +259,9 @@ func (application *Application) initializeConfiguration(command *cobra.Command) 
 	defaultValues := map[string]any{
 		commonLogLevelConfigKeyConstant:  string(utils.LogLevelInfo),
 		commonLogFormatConfigKeyConstant: string(utils.LogFormatStructured),
+	}
+	for configurationKey, configurationValue := range audit.DefaultConfigurationValues(auditConfigurationKeyConstant) {
+		defaultValues[configurationKey] = configurationValue
 	}
 	for configurationKey, configurationValue := range packages.DefaultConfigurationValues() {
 		defaultValues[configurationKey] = configurationValue

--- a/internal/audit/configuration.go
+++ b/internal/audit/configuration.go
@@ -1,0 +1,56 @@
+package audit
+
+import "strings"
+
+const (
+	configurationRootsKeyConstant = "roots"
+	configurationDebugKeyConstant = "debug"
+)
+
+// CommandConfiguration captures persistent settings for the audit command.
+type CommandConfiguration struct {
+	Roots []string `mapstructure:"roots"`
+	Debug bool     `mapstructure:"debug"`
+}
+
+// DefaultCommandConfiguration returns baseline configuration values for the audit command.
+func DefaultCommandConfiguration() CommandConfiguration {
+	return CommandConfiguration{
+		Roots: []string{defaultRootPathConstant},
+		Debug: false,
+	}
+}
+
+// DefaultConfigurationValues exposes Viper-ready defaults for audit configuration keys.
+func DefaultConfigurationValues(rootKey string) map[string]any {
+	defaults := DefaultCommandConfiguration()
+
+	return map[string]any{
+		rootKey + "." + configurationRootsKeyConstant: defaults.Roots,
+		rootKey + "." + configurationDebugKeyConstant: defaults.Debug,
+	}
+}
+
+// sanitize trims whitespace and applies defaults to unset configuration values.
+func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+	sanitized := configuration
+
+	sanitized.Roots = sanitizeRoots(configuration.Roots)
+	if len(sanitized.Roots) == 0 {
+		sanitized.Roots = append([]string{}, defaultRootPathConstant)
+	}
+
+	return sanitized
+}
+
+func sanitizeRoots(raw []string) []string {
+	sanitized := make([]string, 0, len(raw))
+	for index := range raw {
+		trimmed := strings.TrimSpace(raw[index])
+		if len(trimmed) == 0 {
+			continue
+		}
+		sanitized = append(sanitized, trimmed)
+	}
+	return sanitized
+}

--- a/internal/audit/constants.go
+++ b/internal/audit/constants.go
@@ -1,14 +1,13 @@
 package audit
 
 const (
-	commandNameConstant             = "audit"
+	commandUseConstant              = "audit-run"
 	commandShortDescription         = "Audit and reconcile local GitHub repositories"
 	commandLongDescription          = "Scans git repositories for GitHub remotes and produces audit reports or applies reconciliation actions."
-	flagAuditName                   = "audit"
-	flagAuditDescription            = "Generate a CSV audit report"
-	flagDebugName                   = "debug"
-	flagDebugDescription            = "Print debug information while scanning"
-	errorMissingOperation           = "specify --audit"
+	flagRootNameConstant            = "root"
+	flagRootDescriptionConstant     = "Repository roots to scan (repeatable)"
+	flagDebugNameConstant           = "debug"
+	flagDebugDescriptionConstant    = "Print debug information while scanning"
 	defaultRootPathConstant         = "."
 	debugDiscoveredTemplate         = "DEBUG: discovered %d candidate repos under: %s\n"
 	debugCheckingTemplate           = "DEBUG: checking %s\n"

--- a/internal/audit/doc.go
+++ b/internal/audit/doc.go
@@ -1,7 +1,7 @@
 // Package audit implements repository discovery, reporting, and reconciliation
 // workflows used by the git_scripts CLI.
 //
-// It exposes CommandBuilder for wiring Cobra commands, Service for driving the
+// It exposes CommandBuilder for wiring the audit-run Cobra command, Service for driving the
 // workflow programmatically, and supporting abstractions for Git, GitHub, file
 // system, and prompting collaborators.
 package audit

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -48,10 +48,6 @@ func (service *Service) Run(executionContext context.Context, options CommandOpt
 		return inspectionError
 	}
 
-	if !options.AuditReport {
-		return nil
-	}
-
 	return service.writeAuditReport(inspections)
 }
 

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -87,8 +87,7 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 		{
 			name: "audit_report",
 			options: audit.CommandOptions{
-				AuditReport: true,
-				Roots:       []string{"/tmp/example"},
+				Roots: []string{"/tmp/example"},
 			},
 			discoverer: stubDiscoverer{repositories: []string{"/tmp/example"}},
 			executorOutputs: map[string]execshell.ExecutionResult{
@@ -111,7 +110,6 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 		{
 			name: "audit_debug",
 			options: audit.CommandOptions{
-				AuditReport: true,
 				DebugOutput: true,
 				Roots:       []string{"/tmp/example"},
 			},

--- a/internal/audit/types.go
+++ b/internal/audit/types.go
@@ -26,7 +26,6 @@ const (
 // CommandOptions captures the configurable parameters for the audit command.
 type CommandOptions struct {
 	Roots       []string
-	AuditReport bool
 	DebugOutput bool
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `audit-run` command that accepts roots/debug flags and uses configuration defaults
- wire the new audit configuration into the CLI application and document the revised usage
- update integration tests and docs to exercise the new command name and behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5dabebc588327a910d162664e2721