### PR TITLE
Add configuration support for migrate command

### DIFF
--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -55,6 +55,7 @@ const (
 	branchCleanupConfigurationKeyConstant   = toolsConfigurationKeyConstant + ".branch_cleanup"
 	reposConfigurationKeyConstant           = toolsConfigurationKeyConstant + ".repos"
 	workflowConfigurationKeyConstant        = toolsConfigurationKeyConstant + ".workflow"
+	migrateConfigurationKeyConstant         = toolsConfigurationKeyConstant + ".migrate"
 	auditConfigurationKeyConstant           = toolsConfigurationKeyConstant + ".audit"
 )
 
@@ -77,6 +78,7 @@ type ApplicationToolsConfiguration struct {
 	BranchCleanup branches.CommandConfiguration    `mapstructure:"branch_cleanup"`
 	Repos         repos.ToolsConfiguration         `mapstructure:"repos"`
 	Workflow      workflowcmd.CommandConfiguration `mapstructure:"workflow"`
+	Migrate       migrate.CommandConfiguration     `mapstructure:"migrate"`
 }
 
 // Application wires the Cobra root command, configuration loader, and structured logger.
@@ -161,6 +163,9 @@ func NewApplication() *Application {
 			return application.logger
 		},
 		HumanReadableLoggingProvider: application.humanReadableLoggingEnabled,
+		ConfigurationProvider: func() migrate.CommandConfiguration {
+			return application.configuration.Tools.Migrate
+		},
 	}
 	if workingDirectory, workingDirectoryError := os.Getwd(); workingDirectoryError == nil {
 		branchMigrationBuilder.WorkingDirectory = workingDirectory
@@ -273,6 +278,9 @@ func (application *Application) initializeConfiguration(command *cobra.Command) 
 		defaultValues[configurationKey] = configurationValue
 	}
 	for configurationKey, configurationValue := range workflowcmd.DefaultConfigurationValues(workflowConfigurationKeyConstant) {
+		defaultValues[configurationKey] = configurationValue
+	}
+	for configurationKey, configurationValue := range migrate.DefaultConfigurationValues(migrateConfigurationKeyConstant) {
 		defaultValues[configurationKey] = configurationValue
 	}
 

--- a/internal/migrate/configuration.go
+++ b/internal/migrate/configuration.go
@@ -1,0 +1,55 @@
+package migrate
+
+import "strings"
+
+const (
+	migrateConfigurationDebugKeyConstant = "debug"
+	migrateConfigurationRootsKeyConstant = "roots"
+	defaultRepositoryRootConstant        = "."
+)
+
+// CommandConfiguration captures persisted configuration for branch migration.
+type CommandConfiguration struct {
+	EnableDebugLogging bool     `mapstructure:"debug"`
+	RepositoryRoots    []string `mapstructure:"roots"`
+}
+
+// DefaultCommandConfiguration returns baseline configuration values for branch migration.
+func DefaultCommandConfiguration() CommandConfiguration {
+	return CommandConfiguration{
+		EnableDebugLogging: false,
+		RepositoryRoots:    nil,
+	}
+}
+
+// DefaultConfigurationValues exposes configuration defaults for integration with Viper.
+func DefaultConfigurationValues(rootKey string) map[string]any {
+	defaults := DefaultCommandConfiguration()
+
+	return map[string]any{
+		rootKey + "." + migrateConfigurationDebugKeyConstant: defaults.EnableDebugLogging,
+		rootKey + "." + migrateConfigurationRootsKeyConstant: defaults.RepositoryRoots,
+	}
+}
+
+// sanitize trims configured values and removes empty entries.
+func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+	sanitized := configuration
+	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
+	return sanitized
+}
+
+func sanitizeRoots(raw []string) []string {
+	sanitized := make([]string, 0, len(raw))
+	for _, candidate := range raw {
+		trimmed := strings.TrimSpace(candidate)
+		if len(trimmed) == 0 {
+			continue
+		}
+		sanitized = append(sanitized, trimmed)
+	}
+	if len(sanitized) == 0 {
+		return nil
+	}
+	return sanitized
+}


### PR DESCRIPTION
## Summary
- introduce migrate.CommandConfiguration with defaults and sanitization for debug logging and repository roots
- expose migrate settings through the CLI application configuration and register their defaults
- apply configuration precedence in the migrate command builder and extend tests for the new behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d616ba03288327b8a8fada009e336a