### PR TITLE
Add workflow tool references and shared configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,18 @@ common:
 tools:
   packages:
     purge:
-      owner: my-org
-      package: my-image
-      owner_type: org
-      token_source: env:GITHUB_PACKAGES_TOKEN
-      page_size: 50
+      operation: repo-packages-purge
+      with:
+        owner: my-org
+        package: my-image
+        owner_type: org
+        token_source: env:GITHUB_PACKAGES_TOKEN
+        page_size: 50
+  reports:
+    audit:
+      operation: audit-report
+      with:
+        output: ./audit.csv
 steps:
   - operation: convert-protocol
     with:
@@ -122,9 +129,10 @@ steps:
           target_branch: master
           push_to_remote: true
           delete_source_branch: false
-  - operation: audit-report
+  - tool_ref: packages.purge
+  - tool_ref: reports.audit
     with:
-      output: ./audit.csv
+      output: ./reports/audit-latest.csv
 ```
 
 ```shell
@@ -147,6 +155,11 @@ go run . workflow --roots ~/Development --yes
 infrastructure as the standalone commands. Pass additional roots on the command line to override the configuration file
 and
 combine `--dry-run`/`--yes` for non-interactive execution.
+
+Each entry in `steps` can either specify an explicit `operation` with its `with` map or reference a reusable tool
+definition via `tool_ref`. When you supply `tool_ref`, the runner copies the shared defaults defined under `tools` and
+applies any inline overrides you add alongside the reference. Reach for inline `with` maps when a step is unique; prefer
+`tool_ref` when several steps share the same configuration and you want a single place to update future adjustments.
 
 ## Development and testing
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,11 +5,18 @@ common:
 tools:
   packages:
     purge:
-      owner: my-org
-      package: my-image
-      owner_type: org
-      token_source: env:GITHUB_PACKAGES_TOKEN
-      page_size: 50
+      operation: repo-packages-purge
+      with:
+        owner: my-org
+        package: my-image
+        owner_type: org
+        token_source: env:GITHUB_PACKAGES_TOKEN
+        page_size: 50
+  reports:
+    audit:
+      operation: audit-report
+      with:
+        output: ./audit.csv
 steps:
   - operation: convert-protocol
     with:
@@ -27,6 +34,7 @@ steps:
           target_branch: master
           push_to_remote: true
           delete_source_branch: false
-  - operation: audit-report
+  - tool_ref: packages.purge
+  - tool_ref: reports.audit
     with:
-      output: ./audit.csv
+      output: ./reports/audit-latest.csv

--- a/internal/workflow/operations_builder.go
+++ b/internal/workflow/operations_builder.go
@@ -104,10 +104,23 @@ func resolveStepOptions(step StepConfiguration, tools map[string]ToolConfigurati
 		if strings.EqualFold(key, optionToolReferenceKeyConstant) {
 			continue
 		}
+		removeCaseInsensitiveKey(resolved, key)
 		resolved[key] = value
 	}
 
 	return resolved, nil
+}
+
+func removeCaseInsensitiveKey(options map[string]any, target string) {
+	if options == nil {
+		return
+	}
+	for key := range options {
+		if strings.EqualFold(key, target) {
+			delete(options, key)
+			break
+		}
+	}
 }
 
 func copyOptions(source map[string]any) map[string]any {

--- a/internal/workflow/operations_tools_test.go
+++ b/internal/workflow/operations_tools_test.go
@@ -1,0 +1,111 @@
+package workflow_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/internal/repos/shared"
+	"github.com/temirov/git_scripts/internal/workflow"
+)
+
+const (
+	testToolReferenceKeyConstant = "tool_ref"
+	testToolNameConstant         = "shared-protocol"
+	testOptionFromKeyConstant    = "from"
+	testOptionToKeyConstant      = "to"
+	testMissingToolNameConstant  = "missing-tool"
+)
+
+func TestBuildOperationsToolReferenceResolution(testInstance *testing.T) {
+	testCases := []struct {
+		name                 string
+		configuration        workflow.Configuration
+		expectedFromProtocol shared.RemoteProtocol
+		expectedToProtocol   shared.RemoteProtocol
+	}{
+		{
+			name: "uses tool defaults when only reference provided",
+			configuration: workflow.Configuration{
+				Tools: map[string]workflow.ToolConfiguration{
+					testToolNameConstant: {
+						Operation: workflow.OperationTypeProtocolConversion,
+						Options: map[string]any{
+							testOptionFromKeyConstant: string(shared.RemoteProtocolHTTPS),
+							testOptionToKeyConstant:   string(shared.RemoteProtocolSSH),
+						},
+					},
+				},
+				Steps: []workflow.StepConfiguration{
+					{
+						Operation: workflow.OperationTypeProtocolConversion,
+						Options: map[string]any{
+							testToolReferenceKeyConstant: testToolNameConstant,
+						},
+					},
+				},
+			},
+			expectedFromProtocol: shared.RemoteProtocolHTTPS,
+			expectedToProtocol:   shared.RemoteProtocolSSH,
+		},
+		{
+			name: "inline overrides replace tool defaults",
+			configuration: workflow.Configuration{
+				Tools: map[string]workflow.ToolConfiguration{
+					testToolNameConstant: {
+						Operation: workflow.OperationTypeProtocolConversion,
+						Options: map[string]any{
+							testOptionFromKeyConstant: string(shared.RemoteProtocolHTTPS),
+							testOptionToKeyConstant:   string(shared.RemoteProtocolSSH),
+						},
+					},
+				},
+				Steps: []workflow.StepConfiguration{
+					{
+						Operation: workflow.OperationTypeProtocolConversion,
+						Options: map[string]any{
+							testToolReferenceKeyConstant: testToolNameConstant,
+							testOptionToKeyConstant:      string(shared.RemoteProtocolGit),
+						},
+					},
+				},
+			},
+			expectedFromProtocol: shared.RemoteProtocolHTTPS,
+			expectedToProtocol:   shared.RemoteProtocolGit,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			operations, buildError := workflow.BuildOperations(testCase.configuration)
+			require.NoError(testingInstance, buildError)
+			require.Len(testingInstance, operations, 1)
+
+			protocolOperation, typeAssertionSucceeded := operations[0].(*workflow.ProtocolConversionOperation)
+			require.True(testingInstance, typeAssertionSucceeded)
+			require.Equal(testingInstance, testCase.expectedFromProtocol, protocolOperation.FromProtocol)
+			require.Equal(testingInstance, testCase.expectedToProtocol, protocolOperation.ToProtocol)
+		})
+	}
+}
+
+func TestBuildOperationsMissingToolReference(testInstance *testing.T) {
+	configuration := workflow.Configuration{
+		Tools: map[string]workflow.ToolConfiguration{},
+		Steps: []workflow.StepConfiguration{
+			{
+				Operation: workflow.OperationTypeProtocolConversion,
+				Options: map[string]any{
+					testToolReferenceKeyConstant: testMissingToolNameConstant,
+				},
+			},
+		},
+	}
+
+	_, buildError := workflow.BuildOperations(configuration)
+	require.Error(testInstance, buildError)
+
+	var notFoundError workflow.ToolReferenceNotFoundError
+	require.ErrorAs(testInstance, buildError, &notFoundError)
+	require.Equal(testInstance, testMissingToolNameConstant, notFoundError.ToolName)
+}

--- a/internal/workflow/options_reader.go
+++ b/internal/workflow/options_reader.go
@@ -16,6 +16,7 @@ const (
 	optionPushToRemoteKeyConstant       = "push_to_remote"
 	optionDeleteSourceBranchKeyConstant = "delete_source_branch"
 	optionOutputPathKeyConstant         = "output"
+	optionToolReferenceKeyConstant      = "tool_ref"
 )
 
 type optionReader struct {


### PR DESCRIPTION
## Summary
- extend workflow configuration parsing to capture reusable tool definitions and validate their structure
- resolve step tool references when building operations, merging shared defaults with inline overrides
- add workflow unit tests covering tool resolution success, override behavior, and missing definition errors

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7209ca13c8327b5fce6b55370420d