### PR TITLE
Refactor workflow configuration to use anchored tools

### DIFF
--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -52,18 +52,18 @@ const (
 	loggerNotInitializedMessageConstant                = "logger not initialized"
 	defaultConfigurationSearchPathConstant             = "."
 	configurationSearchPathEnvironmentVariableConstant = "GITSCRIPTS_CONFIG_SEARCH_PATH"
-	toolsConfigurationKeyConstant                      = "tools"
-	branchCleanupConfigurationKeyConstant              = toolsConfigurationKeyConstant + ".branch_cleanup"
-	reposConfigurationKeyConstant                      = toolsConfigurationKeyConstant + ".repos"
-	workflowConfigurationKeyConstant                   = toolsConfigurationKeyConstant + ".workflow"
-	migrateConfigurationKeyConstant                    = toolsConfigurationKeyConstant + ".migrate"
-	auditConfigurationKeyConstant                      = toolsConfigurationKeyConstant + ".audit"
+	cliConfigurationKeyConstant                        = "cli"
+	branchCleanupConfigurationKeyConstant              = cliConfigurationKeyConstant + ".branch_cleanup"
+	reposConfigurationKeyConstant                      = cliConfigurationKeyConstant + ".repos"
+	workflowConfigurationKeyConstant                   = cliConfigurationKeyConstant + ".workflow"
+	migrateConfigurationKeyConstant                    = cliConfigurationKeyConstant + ".migrate"
+	auditConfigurationKeyConstant                      = cliConfigurationKeyConstant + ".audit"
 )
 
 // ApplicationConfiguration describes the persisted configuration for the CLI entrypoint.
 type ApplicationConfiguration struct {
 	Common ApplicationCommonConfiguration `mapstructure:"common"`
-	Tools  ApplicationToolsConfiguration  `mapstructure:"tools"`
+	Tools  ApplicationToolsConfiguration  `mapstructure:"cli"`
 }
 
 // ApplicationCommonConfiguration stores logging configuration shared across commands.

--- a/config.yaml
+++ b/config.yaml
@@ -2,53 +2,63 @@
 common:
   log_level: info
   log_format: structured
-tools:
+cli:
   packages:
     purge:
-      operation: repo-packages-purge
-      with:
-        owner: my-org
-        package: my-image
-        owner_type: org
-        token_source: env:GITHUB_PACKAGES_TOKEN
-        page_size: 50
-  reports:
-    audit:
-      operation: audit-report
-      with:
-        output: ./audit.csv
+      owner: my-org
+      package: my-image
+      owner_type: org
+      token_source: env:GITHUB_PACKAGES_TOKEN
+      dry_run: false
+      service_base_url: ""
+      page_size: 50
+  audit:
+    roots:
+      - .
+    debug: false
+tools:
+  - &tool_conversion_default
+    name: conversion.default
+    operation: convert-protocol
+    with: &options_conversion_default
+      from: https
+      to: git
+  - &tool_rename_clean
+    name: rename.clean
+    operation: rename-directories
+    with: &options_rename_clean
+      require_clean: true
+  - &tool_migration_legacy
+    name: migration.legacy
+    operation: migrate-branch
+    with: &options_migration_legacy
+      targets:
+        - remote_name: origin
+          source_branch: main
+          target_branch: master
+          push_to_remote: true
+          delete_source_branch: false
+  - &tool_audit_weekly
+    name: audit.weekly
+    operation: audit-report
+    with: &options_audit_weekly
+      output: ./reports/audit.csv
 workflow:
-  tools:
-    - name: conversion.default
-      operation: convert-protocol
-      with:
-        from: https
-        to: git
-    - name: rename.clean
-      operation: rename-directories
-      with:
-        require_clean: true
-    - name: migration.legacy
-      operation: migrate-branch
-      with:
-        targets:
-          - remote_name: origin
-            source_branch: main
-            target_branch: master
-            push_to_remote: true
-            delete_source_branch: false
-    - name: audit.weekly
-      operation: audit-report
-      with:
-        output: ./reports/audit.csv
-  steps:
-    - with:
-        tool_ref: conversion.default
-    - operation: update-canonical-remote
-    - with:
-        tool_ref: rename.clean
-    - with:
-        tool_ref: migration.legacy
-    - with:
-        tool_ref: audit.weekly
-        output: ./reports/audit-latest.csv
+  - <<: *tool_conversion_default
+    with:
+      <<: *options_conversion_default
+      tool_ref: conversion.default
+  - operation: update-canonical-remote
+  - <<: *tool_rename_clean
+    with:
+      <<: *options_rename_clean
+      tool_ref: rename.clean
+  - <<: *tool_migration_legacy
+    with:
+      <<: *options_migration_legacy
+      tool_ref: migration.legacy
+  - <<: *tool_audit_weekly
+    with:
+      <<: *options_audit_weekly
+      tool_ref: audit.weekly
+      output: ./reports/audit-latest.csv

--- a/internal/packages/configuration.go
+++ b/internal/packages/configuration.go
@@ -1,8 +1,8 @@
 package packages
 
 const (
-	toolsConfigurationRootKeyConstant    = "tools"
-	packagesConfigurationRootKeyConstant = toolsConfigurationRootKeyConstant + ".packages"
+	cliConfigurationRootKeyConstant      = "cli"
+	packagesConfigurationRootKeyConstant = cliConfigurationRootKeyConstant + ".packages"
 	purgeConfigurationKeyConstant        = packagesConfigurationRootKeyConstant + ".purge"
 	purgeOwnerKeyConstant                = purgeConfigurationKeyConstant + ".owner"
 	purgePackageNameKeyConstant          = purgeConfigurationKeyConstant + ".package"

--- a/internal/workflow/operations_tools_test.go
+++ b/internal/workflow/operations_tools_test.go
@@ -24,14 +24,17 @@ const (
 	testSequenceWithToolReferenceCaseName        = "sequence with reusable tool reference"
 	testSequenceWithInlineOperationCaseName      = "sequence with inline operation"
 	emptyOperationTypeConstant                   = workflow.OperationType("")
-	testWorkflowSequenceWithToolReferenceYAML    = `workflow_tools:
-  - name: shared-protocol
+	testWorkflowSequenceWithToolReferenceYAML    = `tools:
+  - &tool_shared_protocol
+    name: shared-protocol
     operation: convert-protocol
-    with:
+    with: &options_shared_protocol
       from: https
       to: ssh
 workflow:
-  - with:
+  - <<: *tool_shared_protocol
+    with:
+      <<: *options_shared_protocol
       tool_ref: shared-protocol
 `
 	testWorkflowSequenceWithoutToolReferenceYAML = `workflow:
@@ -199,11 +202,13 @@ func TestLoadConfigurationWorkflowSequence(testInstance *testing.T) {
 			name:             testSequenceWithToolReferenceCaseName,
 			workflowContents: testWorkflowSequenceWithToolReferenceYAML,
 			expectedOperations: []workflow.OperationType{
-				emptyOperationTypeConstant,
+				workflow.OperationTypeProtocolConversion,
 			},
 			expectedOptionsSlice: []map[string]any{
 				{
 					testToolReferenceKeyConstant: testToolNameConstant,
+					testOptionFromKeyConstant:    string(shared.RemoteProtocolHTTPS),
+					testOptionToKeyConstant:      string(shared.RemoteProtocolSSH),
 				},
 			},
 			expectedToolCount: 1,

--- a/tests/packages_integration_test.go
+++ b/tests/packages_integration_test.go
@@ -23,7 +23,7 @@ const (
 	packagesIntegrationTokenReferenceConstant           = "env:PACKAGES_TOKEN"
 	packagesIntegrationTokenValueConstant               = "packages-token-value"
 	packagesIntegrationConfigFileNameConstant           = "config.yaml"
-	packagesIntegrationConfigTemplateConstant           = "common:\n  log_level: error\ntools:\n  packages:\n    purge:\n      owner: %s\n      package: %s\n      owner_type: %s\n      token_source: %s\n      dry_run: %t\n      service_base_url: %s\n      page_size: %d\n"
+	packagesIntegrationConfigTemplateConstant           = "common:\n  log_level: error\ncli:\n  packages:\n    purge:\n      owner: %s\n      package: %s\n      owner_type: %s\n      token_source: %s\n      dry_run: %t\n      service_base_url: %s\n      page_size: %d\n"
 	packagesIntegrationSubtestNameTemplateConstant      = "%d_%s"
 	packagesIntegrationRunSubcommandConstant            = "run"
 	packagesIntegrationModulePathConstant               = "."

--- a/tests/repos_integration_test.go
+++ b/tests/repos_integration_test.go
@@ -47,7 +47,7 @@ const (
 	reposIntegrationProtocolMissingFlagsMessage = "specify both --from and --to"
 	reposIntegrationConfigFlagName              = "--config"
 	reposIntegrationConfigFileName              = "config.yaml"
-	reposIntegrationConfigTemplate              = "tools:\n  repos:\n    remotes:\n      roots:\n        - %s\n      assume_yes: true\n    protocol:\n      roots:\n        - %s\n      assume_yes: true\n      from: https\n      to: ssh\n"
+	reposIntegrationConfigTemplate              = "cli:\n  repos:\n    remotes:\n      roots:\n        - %s\n      assume_yes: true\n    protocol:\n      roots:\n        - %s\n      assume_yes: true\n      from: https\n      to: ssh\n"
 )
 
 func TestReposCommandIntegration(testInstance *testing.T) {

--- a/tests/workflow_integration_test.go
+++ b/tests/workflow_integration_test.go
@@ -301,33 +301,41 @@ func initializeWorkflowRepository(testInstance *testing.T, repositoryPath string
 func buildWorkflowConfiguration(auditPath string) string {
 	return fmt.Sprintf(`common:
   log_level: error
-tools: {}
-workflow_tools:
-  - name: conversion.default
+tools:
+  - &tool_conversion_default
+    name: conversion.default
     operation: convert-protocol
-    with:
+    with: &options_conversion_default
       from: https
       to: ssh
-  - name: migration.default
+  - &tool_migration_default
+    name: migration.default
     operation: migrate-branch
-    with:
+    with: &options_migration_default
       targets:
         - remote_name: origin
           source_branch: main
           target_branch: master
           push_to_remote: false
           delete_source_branch: false
-  - name: audit.weekly
+  - &tool_audit_weekly
+    name: audit.weekly
     operation: audit-report
-    with:
+    with: &options_audit_weekly
       output: ./reports/audit.csv
 workflow:
-  - with:
+  - <<: *tool_conversion_default
+    with:
+      <<: *options_conversion_default
       tool_ref: conversion.default
   - operation: update-canonical-remote
-  - with:
+  - <<: *tool_migration_default
+    with:
+      <<: *options_migration_default
       tool_ref: migration.default
-  - with:
+  - <<: *tool_audit_weekly
+    with:
+      <<: *options_audit_weekly
       tool_ref: audit.weekly
       output: %s
 `, auditPath)


### PR DESCRIPTION
## Summary
- move workflow tool definitions to a top-level anchored `tools` sequence and add a dedicated `cli` block for command defaults
- update the CLI configuration loader and packages defaults to read from the new `cli` root
- refresh documentation plus integration and unit tests to exercise anchor-based workflow parsing and resolution

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7668e9108832787d5ffc4526d6e92