### PR TITLE
Add multi-repo execution support to repo-packages-purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,15 @@ with the registered command names and flags.
 | `repo-protocol-convert` | Convert repository origin remotes between protocols           | Flags: `--from`, `--to`, `--dry-run`, `--yes`. Example: `go run . repo-protocol-convert --from https --to ssh --yes ~/Development`                                                                                          |
 | `repo-prs-purge`        | Remove remote and local branches for closed pull requests     | Flags: `--remote`, `--limit`, `--dry-run`. Example: `go run . repo-prs-purge --remote origin --limit 100 ~/Development`                                                                                                     |
 | `branch-migrate`        | Migrate repository defaults from main to master               | Flag: `--debug` for verbose diagnostics. Example: `go run . branch-migrate --debug ~/Development/project-repo`                                                                                                              |
-| `repo-packages-purge`   | Delete untagged GHCR versions                                 | Flags: `--package`, `--dry-run`. Example: `go run . repo-packages-purge --package my-image --dry-run` |
+| `repo-packages-purge`   | Delete untagged GHCR versions                                 | Flags: `--package`, `--dry-run`, `--roots`. Example: `go run . repo-packages-purge --package my-image --dry-run --roots ~/Development` |
 | `workflow`              | Run a workflow configuration file                             | Flags: `--roots`, `--dry-run`, `--yes`. Example: `go run . workflow config.yaml --roots ~/Development --dry-run`                                                                                                            |
 
 Persist defaults and workflow plans in a single configuration file to avoid long flag lists and keep the runner in sync:
 
-The purge command derives the GHCR owner and owner type from the active repository's `origin` remote. Ensure the remote
-points at the desired GitHub repository before running the command.
+The purge command derives the GHCR owner and owner type from each repository's `origin` remote. Ensure the remotes
+point at the desired GitHub repositories before running the command. Provide one or more roots with `--roots` or in
+configuration to run the purge across multiple repositories; the command discovers Git repositories beneath every root
+and executes the purge workflow for each repository, continuing after non-fatal errors.
 
 ```yaml
 # config.yaml
@@ -113,6 +115,8 @@ operations:
     operation: repo-packages-purge
     with:
       package: my-image
+      roots:
+        - ~/Development
 
   - &branch_cleanup_defaults
     operation: repo-prs-purge

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,8 @@ operations:
     operation: repo-packages-purge
     with:
       package: my-image
+      roots:
+        - ~/Development
 
   - &branch_cleanup_defaults
     operation: repo-prs-purge

--- a/internal/packages/command_test.go
+++ b/internal/packages/command_test.go
@@ -13,130 +13,271 @@ import (
 	packages "github.com/temirov/git_scripts/internal/packages"
 )
 
-func TestCommandBuilderParsesConfigurationDefaults(testingInstance *testing.T) {
-	testingInstance.Parallel()
+const (
+	configurationRootOnePathConstant      = "/config/root"
+	configurationRootTwoPathConstant      = "/config/alternate"
+	flagRootPathConstant                  = "/flag/root"
+	workingDirectoryPathConstant          = "/working/directory"
+	discoveredRepositoryOnePathConstant   = "/repositories/one"
+	discoveredRepositoryTwoPathConstant   = "/repositories/two"
+	discoveredRepositoryThreePathConstant = "/repositories/three"
+	repositoryOneIdentifierConstant       = "source/example"
+	repositoryTwoIdentifierConstant       = "source/example-two"
+	repositoryThreeIdentifierConstant     = "source/example-three"
+	repositoryOneRemoteURLConstant        = "https://github.com/source/example.git"
+	repositoryTwoRemoteURLConstant        = "https://github.com/source/example-two.git"
+	repositoryThreeRemoteURLConstant      = "https://github.com/source/example-three.git"
+	repositoryOneOwnerConstant            = "canonical"
+	repositoryTwoOwnerConstant            = "second-owner"
+	repositoryThreeOwnerConstant          = "third-owner"
+)
 
-	configuration := packages.Configuration{Purge: packages.PurgeConfiguration{PackageName: "config-package", DryRun: true}}
+func TestCommandBuilderExecutesAcrossRepositories(testInstance *testing.T) {
+	testInstance.Parallel()
 
-	executor := &stubPurgeExecutor{result: ghcr.PurgeResult{TotalVersions: 1}}
-	resolver := &stubServiceResolver{executor: executor}
-	repositoryManager := &stubRepositoryManager{remoteURL: "https://github.com/source/example.git"}
-	githubResolver := &stubGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: "canonical/example", IsInOrganization: true}}
-
-	builder := packages.CommandBuilder{
-		LoggerProvider:           func() *zap.Logger { return zap.NewNop() },
-		ConfigurationProvider:    func() packages.Configuration { return configuration },
-		ServiceResolver:          resolver,
-		RepositoryManager:        repositoryManager,
-		GitHubResolver:           githubResolver,
-		WorkingDirectoryResolver: func() (string, error) { return "/tmp/repo", nil },
-	}
-
-	command, buildError := builder.Build()
-	require.NoError(testingInstance, buildError)
-
-	command.SetContext(context.Background())
-	command.SetArgs([]string{})
-	executionError := command.Execute()
-	require.NoError(testingInstance, executionError)
-
-	require.True(testingInstance, executor.called)
-	require.Equal(testingInstance, "canonical", executor.options.Owner)
-	require.Equal(testingInstance, "config-package", executor.options.PackageName)
-	require.Equal(testingInstance, ghcr.OrganizationOwnerType, executor.options.OwnerType)
-	require.True(testingInstance, executor.options.DryRun)
-	require.Equal(testingInstance, "GITHUB_PACKAGES_TOKEN", executor.options.TokenSource.Reference)
-}
-
-func TestCommandBuilderFlagOverrides(testingInstance *testing.T) {
-	testingInstance.Parallel()
-
-	configuration := packages.Configuration{Purge: packages.PurgeConfiguration{PackageName: "config-package"}}
-	executor := &stubPurgeExecutor{result: ghcr.PurgeResult{TotalVersions: 2}}
-	resolver := &stubServiceResolver{executor: executor}
-
-	repositoryManager := &stubRepositoryManager{remoteURL: "https://github.com/source/example.git"}
-	githubResolver := &stubGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: "canonical/example", IsInOrganization: true}}
-
-	builder := packages.CommandBuilder{
-		LoggerProvider:           func() *zap.Logger { return zap.NewNop() },
-		ConfigurationProvider:    func() packages.Configuration { return configuration },
-		ServiceResolver:          resolver,
-		RepositoryManager:        repositoryManager,
-		GitHubResolver:           githubResolver,
-		WorkingDirectoryResolver: func() (string, error) { return "/tmp/repo", nil },
-	}
-
-	command, buildError := builder.Build()
-	require.NoError(testingInstance, buildError)
-
-	command.SetContext(context.Background())
-	args := []string{
-		"--package", "flag-package",
-		"--dry-run",
-	}
-	command.SetArgs(args)
-	executionError := command.Execute()
-	require.NoError(testingInstance, executionError)
-
-	require.True(testingInstance, executor.called)
-	require.Equal(testingInstance, "canonical", executor.options.Owner)
-	require.Equal(testingInstance, "flag-package", executor.options.PackageName)
-	require.Equal(testingInstance, ghcr.OrganizationOwnerType, executor.options.OwnerType)
-	require.Equal(testingInstance, packages.TokenSourceTypeEnvironment, executor.options.TokenSource.Type)
-	require.Equal(testingInstance, "GITHUB_PACKAGES_TOKEN", executor.options.TokenSource.Reference)
-	require.True(testingInstance, executor.options.DryRun)
-}
-
-func TestCommandBuilderHandlesExecutionError(testingInstance *testing.T) {
-	testingInstance.Parallel()
-
-	executor := &stubPurgeExecutor{err: errors.New("failure")}
-	resolver := &stubServiceResolver{executor: executor}
-
-	builder := packages.CommandBuilder{
-		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
-		ConfigurationProvider: func() packages.Configuration {
-			return packages.Configuration{Purge: packages.PurgeConfiguration{PackageName: "config-package"}}
+	testCases := []struct {
+		name                   string
+		configuration          packages.Configuration
+		arguments              []string
+		discoveredRepositories []string
+		remoteURLsByRepository map[string]string
+		metadataByRepository   map[string]githubcli.RepositoryMetadata
+		expectedPackage        string
+		expectedDryRun         bool
+		expectedOwners         []string
+		expectedOwnerTypes     []ghcr.OwnerType
+		expectedRoots          []string
+	}{
+		{
+			name: "configuration_defaults",
+			configuration: packages.Configuration{Purge: packages.PurgeConfiguration{
+				PackageName:     "config-package",
+				DryRun:          true,
+				RepositoryRoots: []string{configurationRootOnePathConstant},
+			}},
+			arguments: []string{},
+			discoveredRepositories: []string{
+				discoveredRepositoryOnePathConstant,
+				discoveredRepositoryTwoPathConstant,
+			},
+			remoteURLsByRepository: map[string]string{
+				discoveredRepositoryOnePathConstant: repositoryOneRemoteURLConstant,
+				discoveredRepositoryTwoPathConstant: repositoryTwoRemoteURLConstant,
+			},
+			metadataByRepository: map[string]githubcli.RepositoryMetadata{
+				repositoryOneIdentifierConstant: {NameWithOwner: repositoryOneOwnerConstant + "/ignored", IsInOrganization: true},
+				repositoryTwoIdentifierConstant: {NameWithOwner: repositoryTwoOwnerConstant + "/ignored", IsInOrganization: false},
+			},
+			expectedPackage:    "config-package",
+			expectedDryRun:     true,
+			expectedOwners:     []string{repositoryOneOwnerConstant, repositoryTwoOwnerConstant},
+			expectedOwnerTypes: []ghcr.OwnerType{ghcr.OrganizationOwnerType, ghcr.UserOwnerType},
+			expectedRoots:      []string{configurationRootOnePathConstant},
 		},
+		{
+			name: "flag_overrides_configuration",
+			configuration: packages.Configuration{Purge: packages.PurgeConfiguration{
+				PackageName:     "config-package",
+				DryRun:          false,
+				RepositoryRoots: []string{configurationRootTwoPathConstant},
+			}},
+			arguments: []string{
+				"--package", "flag-package",
+				"--dry-run",
+				"--roots", flagRootPathConstant,
+			},
+			discoveredRepositories: []string{
+				discoveredRepositoryThreePathConstant,
+			},
+			remoteURLsByRepository: map[string]string{
+				discoveredRepositoryThreePathConstant: repositoryThreeRemoteURLConstant,
+			},
+			metadataByRepository: map[string]githubcli.RepositoryMetadata{
+				repositoryThreeIdentifierConstant: {NameWithOwner: repositoryThreeOwnerConstant + "/ignored", IsInOrganization: true},
+			},
+			expectedPackage:    "flag-package",
+			expectedDryRun:     true,
+			expectedOwners:     []string{repositoryThreeOwnerConstant},
+			expectedOwnerTypes: []ghcr.OwnerType{ghcr.OrganizationOwnerType},
+			expectedRoots:      []string{flagRootPathConstant},
+		},
+		{
+			name: "falls_back_to_working_directory",
+			configuration: packages.Configuration{Purge: packages.PurgeConfiguration{
+				PackageName: "config-package",
+			}},
+			arguments: []string{},
+			discoveredRepositories: []string{
+				discoveredRepositoryOnePathConstant,
+			},
+			remoteURLsByRepository: map[string]string{
+				discoveredRepositoryOnePathConstant: repositoryOneRemoteURLConstant,
+			},
+			metadataByRepository: map[string]githubcli.RepositoryMetadata{
+				repositoryOneIdentifierConstant: {NameWithOwner: repositoryOneOwnerConstant + "/ignored", IsInOrganization: true},
+			},
+			expectedPackage:    "config-package",
+			expectedDryRun:     false,
+			expectedOwners:     []string{repositoryOneOwnerConstant},
+			expectedOwnerTypes: []ghcr.OwnerType{ghcr.OrganizationOwnerType},
+			expectedRoots:      []string{workingDirectoryPathConstant},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(subTest *testing.T) {
+			subTest.Parallel()
+
+			executor := &stubPurgeExecutor{result: ghcr.PurgeResult{TotalVersions: 1}}
+			resolver := &stubServiceResolver{executor: executor}
+			repositoryManager := &stubRepositoryManager{remoteURLByPath: testCase.remoteURLsByRepository}
+			githubResolver := &stubGitHubResolver{metadataByRepository: testCase.metadataByRepository}
+			discoverer := &stubRepositoryDiscoverer{repositories: testCase.discoveredRepositories}
+
+			builder := packages.CommandBuilder{
+				LoggerProvider:           func() *zap.Logger { return zap.NewNop() },
+				ConfigurationProvider:    func() packages.Configuration { return testCase.configuration },
+				ServiceResolver:          resolver,
+				RepositoryManager:        repositoryManager,
+				GitHubResolver:           githubResolver,
+				RepositoryDiscoverer:     discoverer,
+				WorkingDirectoryResolver: func() (string, error) { return workingDirectoryPathConstant, nil },
+			}
+
+			command, buildError := builder.Build()
+			require.NoError(subTest, buildError)
+
+			command.SetContext(context.Background())
+			command.SetArgs(testCase.arguments)
+			executionError := command.Execute()
+			require.NoError(subTest, executionError)
+
+			require.Len(subTest, executor.executions, len(testCase.discoveredRepositories))
+			for executionIndex, execution := range executor.executions {
+				require.Equal(subTest, testCase.expectedPackage, execution.PackageName)
+				require.Equal(subTest, testCase.expectedDryRun, execution.DryRun)
+				require.Equal(subTest, testCase.expectedOwners[executionIndex], execution.Owner)
+				require.Equal(subTest, testCase.expectedOwnerTypes[executionIndex], execution.OwnerType)
+				require.Equal(subTest, packages.TokenSourceTypeEnvironment, execution.TokenSource.Type)
+				require.Equal(subTest, "GITHUB_PACKAGES_TOKEN", execution.TokenSource.Reference)
+			}
+
+			require.NotEmpty(subTest, discoverer.recordedRoots)
+			lastRoots := discoverer.recordedRoots[len(discoverer.recordedRoots)-1]
+			require.Equal(subTest, testCase.expectedRoots, lastRoots)
+		})
+	}
+}
+
+func TestCommandBuilderAggregatesErrorsAcrossRepositories(testInstance *testing.T) {
+	testInstance.Parallel()
+
+	managerError := errors.New("remote lookup failed")
+	executionError := errors.New("purge failure")
+
+	configuration := packages.Configuration{Purge: packages.PurgeConfiguration{
+		PackageName:     "config-package",
+		RepositoryRoots: []string{configurationRootOnePathConstant},
+	}}
+
+	executor := &stubPurgeExecutor{errorByOwner: map[string]error{repositoryThreeOwnerConstant: executionError}}
+	resolver := &stubServiceResolver{executor: executor}
+	repositoryManager := &stubRepositoryManager{
+		remoteURLByPath: map[string]string{
+			discoveredRepositoryOnePathConstant:   repositoryOneRemoteURLConstant,
+			discoveredRepositoryThreePathConstant: repositoryThreeRemoteURLConstant,
+		},
+		errorByPath: map[string]error{
+			discoveredRepositoryOnePathConstant: managerError,
+		},
+	}
+	githubResolver := &stubGitHubResolver{metadataByRepository: map[string]githubcli.RepositoryMetadata{
+		repositoryThreeIdentifierConstant: {NameWithOwner: repositoryThreeOwnerConstant + "/ignored", IsInOrganization: true},
+	}}
+	discoverer := &stubRepositoryDiscoverer{repositories: []string{discoveredRepositoryOnePathConstant, discoveredRepositoryThreePathConstant}}
+
+	builder := packages.CommandBuilder{
+		LoggerProvider:           func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider:    func() packages.Configuration { return configuration },
 		ServiceResolver:          resolver,
-		RepositoryManager:        &stubRepositoryManager{remoteURL: "https://github.com/source/example.git"},
-		GitHubResolver:           &stubGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: "canonical/example"}},
-		WorkingDirectoryResolver: func() (string, error) { return "/tmp/repo", nil },
+		RepositoryManager:        repositoryManager,
+		GitHubResolver:           githubResolver,
+		RepositoryDiscoverer:     discoverer,
+		WorkingDirectoryResolver: func() (string, error) { return workingDirectoryPathConstant, nil },
 	}
 
 	command, buildError := builder.Build()
-	require.NoError(testingInstance, buildError)
+	require.NoError(testInstance, buildError)
 
 	command.SetContext(context.Background())
-	command.SetArgs([]string{"--package", "p"})
-	executionError := command.Execute()
-	require.Error(testingInstance, executionError)
-	require.ErrorContains(testingInstance, executionError, "repo-packages-purge failed")
+	executionErrorResult := command.Execute()
+	require.Error(testInstance, executionErrorResult)
+	require.ErrorContains(testInstance, executionErrorResult, "unable to resolve repository context")
+	require.ErrorContains(testInstance, executionErrorResult, "repo-packages-purge failed")
+	require.Len(testInstance, executor.executions, 1)
+	require.Equal(testInstance, repositoryThreeOwnerConstant, executor.executions[0].Owner)
 }
 
-func TestCommandBuilderValidatesArguments(testingInstance *testing.T) {
-	testingInstance.Parallel()
+func TestCommandBuilderPropagatesContextCancellation(testInstance *testing.T) {
+	testInstance.Parallel()
+
+	configuration := packages.Configuration{Purge: packages.PurgeConfiguration{
+		PackageName:     "config-package",
+		RepositoryRoots: []string{configurationRootOnePathConstant},
+	}}
+
+	executor := &stubPurgeExecutor{defaultError: context.Canceled}
+	resolver := &stubServiceResolver{executor: executor}
+	repositoryManager := &stubRepositoryManager{remoteURLByPath: map[string]string{
+		discoveredRepositoryOnePathConstant: repositoryOneRemoteURLConstant,
+	}}
+	githubResolver := &stubGitHubResolver{metadataByRepository: map[string]githubcli.RepositoryMetadata{
+		repositoryOneIdentifierConstant: {NameWithOwner: repositoryOneOwnerConstant + "/ignored", IsInOrganization: true},
+	}}
+	discoverer := &stubRepositoryDiscoverer{repositories: []string{discoveredRepositoryOnePathConstant}}
+
+	builder := packages.CommandBuilder{
+		LoggerProvider:           func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider:    func() packages.Configuration { return configuration },
+		ServiceResolver:          resolver,
+		RepositoryManager:        repositoryManager,
+		GitHubResolver:           githubResolver,
+		RepositoryDiscoverer:     discoverer,
+		WorkingDirectoryResolver: func() (string, error) { return workingDirectoryPathConstant, nil },
+	}
+
+	command, buildError := builder.Build()
+	require.NoError(testInstance, buildError)
+
+	command.SetContext(context.Background())
+	executionError := command.Execute()
+	require.Error(testInstance, executionError)
+	require.ErrorIs(testInstance, executionError, context.Canceled)
+}
+
+func TestCommandBuilderValidatesArguments(testInstance *testing.T) {
+	testInstance.Parallel()
 
 	builder := packages.CommandBuilder{
 		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
 		ConfigurationProvider: func() packages.Configuration {
-			return packages.Configuration{Purge: packages.PurgeConfiguration{PackageName: "config-package"}}
+			return packages.Configuration{Purge: packages.PurgeConfiguration{PackageName: "config-package", RepositoryRoots: []string{configurationRootOnePathConstant}}}
 		},
 		ServiceResolver:          &stubServiceResolver{executor: &stubPurgeExecutor{}},
-		RepositoryManager:        &stubRepositoryManager{remoteURL: "https://github.com/source/example.git"},
-		GitHubResolver:           &stubGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: "canonical/example"}},
-		WorkingDirectoryResolver: func() (string, error) { return "/tmp/repo", nil },
+		RepositoryManager:        &stubRepositoryManager{remoteURLByPath: map[string]string{discoveredRepositoryOnePathConstant: repositoryOneRemoteURLConstant}},
+		GitHubResolver:           &stubGitHubResolver{metadataByRepository: map[string]githubcli.RepositoryMetadata{repositoryOneIdentifierConstant: {NameWithOwner: repositoryOneOwnerConstant + "/ignored", IsInOrganization: true}}},
+		RepositoryDiscoverer:     &stubRepositoryDiscoverer{repositories: []string{discoveredRepositoryOnePathConstant}},
+		WorkingDirectoryResolver: func() (string, error) { return workingDirectoryPathConstant, nil },
 	}
 
 	command, buildError := builder.Build()
-	require.NoError(testingInstance, buildError)
+	require.NoError(testInstance, buildError)
 
 	command.SetContext(context.Background())
 	command.SetArgs([]string{"unexpected"})
 	executionError := command.Execute()
-	require.Error(testingInstance, executionError)
-	require.ErrorContains(testingInstance, executionError, "does not accept positional arguments")
+	require.Error(testInstance, executionError)
+	require.ErrorContains(testInstance, executionError, "does not accept positional arguments")
 }
 
 type stubServiceResolver struct {
@@ -152,23 +293,29 @@ func (resolver *stubServiceResolver) Resolve(logger *zap.Logger) (packages.Purge
 }
 
 type stubPurgeExecutor struct {
-	options packages.PurgeOptions
-	result  ghcr.PurgeResult
-	err     error
-	called  bool
+	executions   []packages.PurgeOptions
+	result       ghcr.PurgeResult
+	defaultError error
+	errorByOwner map[string]error
 }
 
 func (executor *stubPurgeExecutor) Execute(executionContext context.Context, options packages.PurgeOptions) (ghcr.PurgeResult, error) {
-	executor.called = true
-	executor.options = options
-	if executor.err != nil {
-		return ghcr.PurgeResult{}, executor.err
+	executor.executions = append(executor.executions, options)
+	if executor.errorByOwner != nil {
+		if ownerError, exists := executor.errorByOwner[options.Owner]; exists {
+			return ghcr.PurgeResult{}, ownerError
+		}
+	}
+	if executor.defaultError != nil {
+		return ghcr.PurgeResult{}, executor.defaultError
 	}
 	return executor.result, nil
 }
 
 type stubRepositoryManager struct {
-	remoteURL string
+	remoteURLByPath         map[string]string
+	errorByPath             map[string]error
+	recordedRepositoryPaths []string
 }
 
 func (manager *stubRepositoryManager) CheckCleanWorktree(ctx context.Context, repositoryPath string) (bool, error) {
@@ -180,7 +327,18 @@ func (manager *stubRepositoryManager) GetCurrentBranch(ctx context.Context, repo
 }
 
 func (manager *stubRepositoryManager) GetRemoteURL(ctx context.Context, repositoryPath string, remoteName string) (string, error) {
-	return manager.remoteURL, nil
+	manager.recordedRepositoryPaths = append(manager.recordedRepositoryPaths, repositoryPath)
+	if manager.errorByPath != nil {
+		if lookupError, exists := manager.errorByPath[repositoryPath]; exists {
+			return "", lookupError
+		}
+	}
+	if manager.remoteURLByPath != nil {
+		if remoteURL, exists := manager.remoteURLByPath[repositoryPath]; exists {
+			return remoteURL, nil
+		}
+	}
+	return "", errors.New("remote not found")
 }
 
 func (manager *stubRepositoryManager) SetRemoteURL(ctx context.Context, repositoryPath string, remoteName string, remoteURL string) error {
@@ -188,15 +346,37 @@ func (manager *stubRepositoryManager) SetRemoteURL(ctx context.Context, reposito
 }
 
 type stubGitHubResolver struct {
-	metadata           githubcli.RepositoryMetadata
-	err                error
-	recordedRepository string
+	metadata             githubcli.RepositoryMetadata
+	metadataByRepository map[string]githubcli.RepositoryMetadata
+	err                  error
+	recordedRepositories []string
 }
 
 func (resolver *stubGitHubResolver) ResolveRepoMetadata(ctx context.Context, repository string) (githubcli.RepositoryMetadata, error) {
-	resolver.recordedRepository = repository
+	resolver.recordedRepositories = append(resolver.recordedRepositories, repository)
 	if resolver.err != nil {
 		return githubcli.RepositoryMetadata{}, resolver.err
 	}
+	if resolver.metadataByRepository != nil {
+		if metadata, exists := resolver.metadataByRepository[repository]; exists {
+			return metadata, nil
+		}
+	}
 	return resolver.metadata, nil
+}
+
+type stubRepositoryDiscoverer struct {
+	repositories  []string
+	err           error
+	recordedRoots [][]string
+}
+
+func (discoverer *stubRepositoryDiscoverer) DiscoverRepositories(roots []string) ([]string, error) {
+	copiedRoots := make([]string, len(roots))
+	copy(copiedRoots, roots)
+	discoverer.recordedRoots = append(discoverer.recordedRoots, copiedRoots)
+	if discoverer.err != nil {
+		return nil, discoverer.err
+	}
+	return discoverer.repositories, nil
 }

--- a/internal/packages/configuration.go
+++ b/internal/packages/configuration.go
@@ -1,5 +1,7 @@
 package packages
 
+import "strings"
+
 const (
 	defaultTokenSourceValueConstant = "env:GITHUB_PACKAGES_TOKEN"
 )
@@ -11,8 +13,9 @@ type Configuration struct {
 
 // PurgeConfiguration stores options for purging container versions.
 type PurgeConfiguration struct {
-	PackageName string `mapstructure:"package"`
-	DryRun      bool   `mapstructure:"dry_run"`
+	PackageName     string   `mapstructure:"package"`
+	DryRun          bool     `mapstructure:"dry_run"`
+	RepositoryRoots []string `mapstructure:"roots"`
 }
 
 // DefaultConfiguration supplies baseline values for packages configuration.
@@ -20,4 +23,32 @@ func DefaultConfiguration() Configuration {
 	return Configuration{
 		Purge: PurgeConfiguration{},
 	}
+}
+
+// sanitize trims configured values and removes empty entries.
+func (configuration Configuration) sanitize() Configuration {
+	sanitized := configuration
+	sanitized.Purge = configuration.Purge.sanitize()
+	return sanitized
+}
+
+func (configuration PurgeConfiguration) sanitize() PurgeConfiguration {
+	sanitized := configuration
+	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
+	return sanitized
+}
+
+func sanitizeRoots(candidateRoots []string) []string {
+	sanitizedRoots := make([]string, 0, len(candidateRoots))
+	for _, rootCandidate := range candidateRoots {
+		trimmedRoot := strings.TrimSpace(rootCandidate)
+		if len(trimmedRoot) == 0 {
+			continue
+		}
+		sanitizedRoots = append(sanitizedRoots, trimmedRoot)
+	}
+	if len(sanitizedRoots) == 0 {
+		return nil
+	}
+	return sanitizedRoots
 }

--- a/tests/packages_integration_test.go
+++ b/tests/packages_integration_test.go
@@ -23,7 +23,7 @@ const (
 	packagesIntegrationTokenValueConstant               = "packages-token-value"
 	packagesIntegrationBaseURLEnvironmentNameConstant   = "GITSCRIPTS_REPO_PACKAGES_PURGE_BASE_URL"
 	packagesIntegrationConfigFileNameConstant           = "config.yaml"
-	packagesIntegrationConfigTemplateConstant           = "common:\n  log_level: error\noperations:\n  - operation: repo-packages-purge\n    with:\n      package: %s\n      dry_run: %t\nworkflow: []\n"
+	packagesIntegrationConfigTemplateConstant           = "common:\n  log_level: error\noperations:\n  - operation: repo-packages-purge\n    with:\n      package: %s\n      dry_run: %t\n      roots:\n        - %s\nworkflow: []\n"
 	packagesIntegrationSubtestNameTemplateConstant      = "%d_%s"
 	packagesIntegrationRunSubcommandConstant            = "run"
 	packagesIntegrationModulePathConstant               = "."
@@ -216,6 +216,7 @@ func TestPackagesCommandIntegration(testInstance *testing.T) {
 				packagesIntegrationConfigTemplateConstant,
 				packagesIntegrationPackageConstant,
 				testCase.dryRun,
+				repositoryRoot,
 			)
 
 			writeError := os.WriteFile(configPath, []byte(configContent), 0o600)


### PR DESCRIPTION
## Summary
- add repository discovery and roots flag handling to the repo-packages-purge command
- expand packages configuration, defaults, and documentation for multi-repository execution
- update unit and integration tests to cover repository iteration and configuration roots

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d841c6f8888327b3ef5b153eeb6930