### PR TITLE
Validate operation configuration presence during initialization

### DIFF
--- a/cmd/cli/application_test.go
+++ b/cmd/cli/application_test.go
@@ -1,0 +1,133 @@
+package cli_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/cmd/cli"
+)
+
+const (
+	testConfigurationFileNameConstant          = "config.yaml"
+	testConfigurationHeaderConstant            = "common:\n  log_level: info\n  log_format: structured\noperations:\n"
+	testOperationBlockTemplateConstant         = "  - operation: %s\n    with:\n%s"
+	testOperationRootsTemplateConstant         = "      roots:\n        - %s\n"
+	testOperationRootDirectoryConstant         = "/tmp/config-root"
+	testConfigurationSearchPathEnvironmentName = "GITSCRIPTS_CONFIG_SEARCH_PATH"
+	testPackagesCommandNameConstant            = "repo-packages-purge"
+	testBranchMigrateCommandNameConstant       = "branch-migrate"
+)
+
+var requiredOperationNames = []string{
+	"audit",
+	"repo-packages-purge",
+	"repo-prs-purge",
+	"repo-folders-rename",
+	"repo-remote-update",
+	"repo-protocol-convert",
+	"workflow",
+	"branch-migrate",
+}
+
+func TestApplicationInitializeConfiguration(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		operationNames        []string
+		expectedErrorSample   error
+		expectedOperationName string
+		commandUse            string
+	}{
+		{
+			name:           "ValidConfiguration",
+			operationNames: requiredOperationNames,
+			commandUse:     testPackagesCommandNameConstant,
+		},
+		{
+			name: "DuplicateOperationConfiguration",
+			operationNames: append([]string{
+				"audit",
+				"Audit",
+			}, requiredOperationNames[1:]...),
+			expectedErrorSample:   &cli.DuplicateOperationConfigurationError{},
+			expectedOperationName: "audit",
+			commandUse:            testPackagesCommandNameConstant,
+		},
+		{
+			name: "MissingOperationConfiguration",
+			operationNames: []string{
+				"audit",
+				"repo-packages-purge",
+				"repo-prs-purge",
+				"repo-folders-rename",
+				"repo-remote-update",
+				"repo-protocol-convert",
+				"workflow",
+			},
+			expectedErrorSample:   &cli.MissingOperationConfigurationError{},
+			expectedOperationName: "branch-migrate",
+			commandUse:            testBranchMigrateCommandNameConstant,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			temporaryDirectory := t.TempDir()
+			configurationContent := buildConfigurationContent(testCase.operationNames)
+			configurationPath := filepath.Join(temporaryDirectory, testConfigurationFileNameConstant)
+
+			writeConfigurationFile(t, configurationPath, configurationContent)
+
+			t.Setenv(testConfigurationSearchPathEnvironmentName, temporaryDirectory)
+
+			application := cli.NewApplication()
+
+			executionError := application.InitializeForCommand(testCase.commandUse)
+
+			if testCase.expectedErrorSample == nil {
+				require.NoError(t, executionError)
+				return
+			}
+
+			require.Error(t, executionError)
+
+			switch testCase.expectedErrorSample.(type) {
+			case *cli.DuplicateOperationConfigurationError:
+				var duplicateError cli.DuplicateOperationConfigurationError
+				require.ErrorAs(t, executionError, &duplicateError)
+				require.Equal(t, testCase.expectedOperationName, duplicateError.OperationName)
+			case *cli.MissingOperationConfigurationError:
+				var missingError cli.MissingOperationConfigurationError
+				require.ErrorAs(t, executionError, &missingError)
+				require.Equal(t, testCase.expectedOperationName, missingError.OperationName)
+			default:
+				t.Fatalf("unexpected error sample type %T", testCase.expectedErrorSample)
+			}
+		})
+	}
+}
+
+func buildConfigurationContent(operationNames []string) string {
+	configurationBuilder := strings.Builder{}
+	configurationBuilder.WriteString(testConfigurationHeaderConstant)
+
+	for _, operationName := range operationNames {
+		rootsBlock := fmt.Sprintf(testOperationRootsTemplateConstant, testOperationRootDirectoryConstant)
+		operationBlock := fmt.Sprintf(testOperationBlockTemplateConstant, operationName, rootsBlock)
+		configurationBuilder.WriteString(operationBlock)
+	}
+
+	return configurationBuilder.String()
+}
+
+func writeConfigurationFile(t *testing.T, configurationPath string, configurationContent string) {
+	t.Helper()
+
+	writeError := os.WriteFile(configurationPath, []byte(configurationContent), 0o600)
+	require.NoError(t, writeError)
+}

--- a/tests/workflow_integration_test.go
+++ b/tests/workflow_integration_test.go
@@ -302,6 +302,13 @@ func buildWorkflowConfiguration(auditPath string) string {
 	return fmt.Sprintf(`common:
   log_level: error
 operations:
+  - &workflow_defaults
+    operation: workflow
+    with:
+      roots:
+        - .
+      dry_run: false
+      assume_yes: false
   - &conversion_default
     operation: convert-protocol
     with:


### PR DESCRIPTION
## Summary
- add duplicate and missing operation configuration detection with custom errors and a Lookup helper
- validate command-specific defaults during initialization and expose InitializeForCommand for reuse
- add CLI initialization tests and include workflow defaults in integration configuration

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d85805ad648327b2cc30e9d41a2901