### PR TITLE
Refine workflow configuration defaults and validate README example

### DIFF
--- a/cmd/cli/workflow/run_test.go
+++ b/cmd/cli/workflow/run_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	workflowConfigFileNameConstant = "config.yaml"
-	workflowConfigContentConstant  = "operations:\n  - operation: audit-report\nworkflow:\n  - step:\n      operation: audit-report\n"
+	workflowConfigContentConstant  = "operations:\n  - operation: workflow\n    with:\n      roots:\n        - .\nworkflow:\n  - step:\n      operation: audit-report\n"
 	workflowConfiguredRootConstant = "/tmp/workflow-config-root"
 	workflowCliRootConstant        = "/tmp/workflow-cli-root"
 	workflowPlanMessageSnippet     = "WORKFLOW-PLAN: audit report"

--- a/config.yaml
+++ b/config.yaml
@@ -4,40 +4,35 @@ common:
   log_format: structured
 
 operations:
-  - &audit_defaults
-    operation: audit
-    with:
+  - operation: audit
+    with: &audit_defaults
       roots:
         - ~/Development
       debug: false
 
-  - &packages_purge_defaults
-    operation: repo-packages-purge
-    with:
+  - operation: repo-packages-purge
+    with: &packages_purge_defaults
       # package: my-image  # Optional override; defaults to the repository name
       roots:
         - ~/Development
 
-  - &branch_cleanup_defaults
-    operation: repo-prs-purge
-    with:
+  - operation: repo-prs-purge
+    with: &branch_cleanup_defaults
       remote: origin
       limit: 100
       dry_run: false
       roots:
         - ~/Development
 
-  - &repo_remotes_defaults
-    operation: repo-remote-update
-    with:
+  - operation: repo-remote-update
+    with: &repo_remotes_defaults
       dry_run: false
       assume_yes: true
       roots:
         - ~/Development
 
-  - &repo_protocol_defaults
-    operation: repo-protocol-convert
-    with:
+  - operation: repo-protocol-convert
+    with: &repo_protocol_defaults
       dry_run: false
       assume_yes: true
       roots:
@@ -45,78 +40,60 @@ operations:
       from: https
       to: git
 
-  - &repo_rename_defaults
-    operation: repo-folders-rename
-    with:
+  - operation: repo-folders-rename
+    with: &repo_rename_defaults
       dry_run: false
       assume_yes: true
       require_clean: true
       roots:
         - ~/Development
 
-  - &workflow_command_defaults
-    operation: workflow
-    with:
+  - operation: workflow
+    with: &workflow_command_defaults
       roots:
         - ~/Development
       dry_run: false
       assume_yes: false
 
-  - &branch_migrate_defaults
-    operation: branch-migrate
-    with:
+  - operation: branch-migrate
+    with: &branch_migrate_defaults
       debug: false
       roots:
         - ~/Development
 
-  - &convert_protocol_step
-    operation: convert-protocol
-    with:
-      from: https
-      to: git
-
-  - &canonical_remote_step
-    operation: update-canonical-remote
-
-  - &rename_directories_step
-    operation: rename-directories
-    with:
-      require_clean: true
-
-  - &migrate_branch_step
-    operation: migrate-branch
-    with:
-      targets:
-        - remote_name: origin
-          source_branch: main
-          target_branch: master
-          push_to_remote: true
-          delete_source_branch: false
-
-  - &audit_report_step
-    operation: audit-report
-    with:
-      output: ./reports/audit.csv
-
 workflow:
   - step:
       order: 1
-      <<: *convert_protocol_step
+      operation: convert-protocol
+      with:
+        <<: *repo_protocol_defaults
 
   - step:
       order: 2
-      <<: *canonical_remote_step
+      operation: update-canonical-remote
+      with:
+        <<: *repo_remotes_defaults
 
   - step:
       order: 3
-      <<: *rename_directories_step
+      operation: rename-directories
+      with:
+        <<: *repo_rename_defaults
 
   - step:
       order: 4
-      <<: *migrate_branch_step
+      operation: migrate-branch
+      with:
+        <<: *branch_migrate_defaults
+        targets:
+          - remote_name: origin
+            source_branch: main
+            target_branch: master
+            push_to_remote: true
+            delete_source_branch: false
 
   - step:
       order: 5
-      <<: *audit_report_step
+      operation: audit-report
       with:
         output: ./reports/audit-latest.csv

--- a/docs/readme_config_test.go
+++ b/docs/readme_config_test.go
@@ -1,0 +1,118 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/temirov/git_scripts/internal/workflow"
+)
+
+const (
+	readmeFileNameConstant             = "README.md"
+	yamlFenceStartConstant             = "```yaml"
+	yamlFenceEndConstant               = "```"
+	configHeaderMarkerConstant         = "# config.yaml"
+	readmeSnippetTestNameConstant      = "readme_workflow_configuration"
+	readmeSnippetTemporaryPattern      = "readme-config-*.yaml"
+	expectedOperationCount             = 8
+	parentDirectoryReferenceConstant   = ".."
+	missingHeaderMessageConstant       = "README example missing config header marker"
+	missingStartFenceMessageConstant   = "README example missing yaml fence start"
+	missingEndFenceMessageConstant     = "README example missing yaml fence end"
+	unexpectedOperationMessageTemplate = "unexpected operation %s"
+	duplicateOperationMessageTemplate  = "duplicate operation %s"
+	defaultTempDirectoryRootConstant   = ""
+)
+
+var expectedCommandOperations = map[string]struct{}{
+	"audit":                 {},
+	"repo-packages-purge":   {},
+	"repo-prs-purge":        {},
+	"repo-remote-update":    {},
+	"repo-protocol-convert": {},
+	"repo-folders-rename":   {},
+	"workflow":              {},
+	"branch-migrate":        {},
+}
+
+type readmeApplicationConfiguration struct {
+	Operations []readmeOperationConfiguration `yaml:"operations"`
+}
+
+type readmeOperationConfiguration struct {
+	Operation string         `yaml:"operation"`
+	Options   map[string]any `yaml:"with"`
+}
+
+func TestReadmeWorkflowConfigurationParses(testInstance *testing.T) {
+	workingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+
+	readmePath := filepath.Join(workingDirectory, parentDirectoryReferenceConstant, readmeFileNameConstant)
+	contentBytes, readError := os.ReadFile(readmePath)
+	require.NoError(testInstance, readError)
+
+	contentText := string(contentBytes)
+	headerIndex := strings.Index(contentText, configHeaderMarkerConstant)
+	require.NotEqual(testInstance, -1, headerIndex, missingHeaderMessageConstant)
+
+	fenceStartIndex := strings.LastIndex(contentText[:headerIndex], yamlFenceStartConstant)
+	require.NotEqual(testInstance, -1, fenceStartIndex, missingStartFenceMessageConstant)
+
+	remainingText := contentText[headerIndex:]
+	fenceEndRelativeIndex := strings.Index(remainingText, yamlFenceEndConstant)
+	require.NotEqual(testInstance, -1, fenceEndRelativeIndex, missingEndFenceMessageConstant)
+	fenceEndIndex := headerIndex + fenceEndRelativeIndex
+
+	snippetContent := strings.TrimSpace(contentText[fenceStartIndex+len(yamlFenceStartConstant) : fenceEndIndex])
+
+	testCases := []struct {
+		name          string
+		configuration string
+	}{
+		{
+			name:          readmeSnippetTestNameConstant,
+			configuration: snippetContent,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testInstance.Run(testCase.name, func(subtest *testing.T) {
+			tempFile, tempFileError := os.CreateTemp(defaultTempDirectoryRootConstant, readmeSnippetTemporaryPattern)
+			require.NoError(subtest, tempFileError)
+			subtest.Cleanup(func() {
+				require.NoError(subtest, os.Remove(tempFile.Name()))
+			})
+
+			_, writeError := tempFile.WriteString(testCase.configuration)
+			require.NoError(subtest, writeError)
+			require.NoError(subtest, tempFile.Close())
+
+			_, workflowError := workflow.LoadConfiguration(tempFile.Name())
+			require.NoError(subtest, workflowError)
+
+			var applicationConfiguration readmeApplicationConfiguration
+			unmarshalError := yaml.Unmarshal([]byte(testCase.configuration), &applicationConfiguration)
+			require.NoError(subtest, unmarshalError)
+
+			require.Len(subtest, applicationConfiguration.Operations, expectedOperationCount)
+
+			seenOperations := make(map[string]struct{}, len(applicationConfiguration.Operations))
+			for _, operationConfig := range applicationConfiguration.Operations {
+				normalizedName := strings.TrimSpace(strings.ToLower(operationConfig.Operation))
+				_, expected := expectedCommandOperations[normalizedName]
+				require.Truef(subtest, expected, unexpectedOperationMessageTemplate, normalizedName)
+
+				_, duplicate := seenOperations[normalizedName]
+				require.Falsef(subtest, duplicate, duplicateOperationMessageTemplate, normalizedName)
+				seenOperations[normalizedName] = struct{}{}
+			}
+		})
+	}
+}

--- a/tests/workflow_integration_test.go
+++ b/tests/workflow_integration_test.go
@@ -302,42 +302,53 @@ func buildWorkflowConfiguration(auditPath string) string {
 	return fmt.Sprintf(`common:
   log_level: error
 operations:
-  - &workflow_defaults
-    operation: workflow
-    with:
+  - operation: workflow
+    with: &workflow_defaults
       roots:
         - .
       dry_run: false
       assume_yes: false
-  - &conversion_default
-    operation: convert-protocol
-    with:
+  - operation: repo-protocol-convert
+    with: &conversion_defaults
+      roots:
+        - .
+      assume_yes: true
+      dry_run: false
       from: https
       to: ssh
-  - &migration_default
-    operation: migrate-branch
-    with:
+  - operation: repo-remote-update
+    with: &remote_defaults
+      roots:
+        - .
+      assume_yes: true
+      dry_run: false
+  - operation: branch-migrate
+    with: &migration_defaults
+      roots:
+        - .
+      debug: false
       targets:
         - remote_name: origin
           source_branch: main
           target_branch: master
           push_to_remote: false
           delete_source_branch: false
-  - &audit_weekly
-    operation: audit-report
-    with: &audit_weekly_options
-      output: ./reports/audit.csv
 workflow:
   - step:
-      <<: *conversion_default
+      operation: convert-protocol
+      with:
+        <<: *conversion_defaults
   - step:
       operation: update-canonical-remote
-  - step:
-      <<: *migration_default
-  - step:
-      <<: *audit_weekly
       with:
-        <<: *audit_weekly_options
+        <<: *remote_defaults
+  - step:
+      operation: migrate-branch
+      with:
+        <<: *migration_defaults
+  - step:
+      operation: audit-report
+      with:
         output: %s
 `, auditPath)
 }


### PR DESCRIPTION
## Summary
- restructure config.yaml so operations entries represent CLI commands and workflow steps reuse their option maps
- update the README workflow example and guidance to mirror the new configuration layout
- refresh workflow tests and add a README parsing test to ensure the documented example stays valid

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d86414bd208327a349165d4d5d818a