### PR TITLE
Validate branch cleanup remote and limit inputs

### DIFF
--- a/internal/branches/configuration.go
+++ b/internal/branches/configuration.go
@@ -13,25 +13,18 @@ type CommandConfiguration struct {
 // DefaultCommandConfiguration provides baseline configuration values for branch cleanup.
 func DefaultCommandConfiguration() CommandConfiguration {
 	return CommandConfiguration{
-		RemoteName:       defaultRemoteNameConstant,
-		PullRequestLimit: defaultPullRequestLimitConstant,
+		RemoteName:       "",
+		PullRequestLimit: 0,
 		DryRun:           false,
 		RepositoryRoots:  nil,
 	}
 }
 
-// sanitize populates zero values with defaults and trims whitespace.
+// sanitize trims configuration values without applying implicit defaults.
 func (configuration CommandConfiguration) sanitize() CommandConfiguration {
 	sanitized := configuration
 
-	if len(strings.TrimSpace(configuration.RemoteName)) == 0 {
-		sanitized.RemoteName = defaultRemoteNameConstant
-	}
-
-	if configuration.PullRequestLimit <= 0 {
-		sanitized.PullRequestLimit = defaultPullRequestLimitConstant
-	}
-
+	sanitized.RemoteName = strings.TrimSpace(configuration.RemoteName)
 	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
 
 	return sanitized


### PR DESCRIPTION
## Summary
- stop injecting implicit defaults into the branch-cleanup configuration so remote and limit values remain empty until validated
- validate remote names and pull-request limits during option parsing, surfacing descriptive errors via Cobra help output
- expand branch-cleanup command tests to cover CLI defaults along with new CLI and configuration validation failures

## Testing
- go test ./internal/branches

------
https://chatgpt.com/codex/tasks/task_e_68d868cbec448327b610558dea9b5bdd