### PR TITLE
Handle missing operation configuration gracefully

### DIFF
--- a/cmd/cli/application_test.go
+++ b/cmd/cli/application_test.go
@@ -58,7 +58,7 @@ func TestApplicationInitializeConfiguration(t *testing.T) {
 			commandUse:            testPackagesCommandNameConstant,
 		},
 		{
-			name: "MissingOperationConfiguration",
+			name: "CommandConfigurationMissingForTargetCommandIgnored",
 			operationNames: []string{
 				"audit",
 				"repo-packages-purge",
@@ -68,9 +68,7 @@ func TestApplicationInitializeConfiguration(t *testing.T) {
 				"repo-protocol-convert",
 				"workflow",
 			},
-			expectedErrorSample:   &cli.MissingOperationConfigurationError{},
-			expectedOperationName: "branch-migrate",
-			commandUse:            testBranchMigrateCommandNameConstant,
+			commandUse: testBranchMigrateCommandNameConstant,
 		},
 	}
 

--- a/internal/audit/command_test.go
+++ b/internal/audit/command_test.go
@@ -1,0 +1,71 @@
+package audit_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	audit "github.com/temirov/git_scripts/internal/audit"
+)
+
+const (
+	auditMissingRootsErrorMessageConstant = "no repository roots provided; specify --root or configure defaults"
+	auditWhitespaceRootArgumentConstant   = "   "
+	auditRootFlagNameConstant             = "--root"
+	auditConfigurationMissingSubtestName  = "configuration_and_flags_missing"
+	auditWhitespaceRootFlagSubtestName    = "flag_provided_without_roots"
+)
+
+func TestCommandBuilderDisplaysHelpWhenRootsMissing(testInstance *testing.T) {
+	testInstance.Parallel()
+
+	testCases := []struct {
+		name          string
+		configuration audit.CommandConfiguration
+		arguments     []string
+	}{
+		{
+			name:          auditConfigurationMissingSubtestName,
+			configuration: audit.CommandConfiguration{},
+			arguments:     []string{},
+		},
+		{
+			name:          auditWhitespaceRootFlagSubtestName,
+			configuration: audit.CommandConfiguration{},
+			arguments: []string{
+				auditRootFlagNameConstant,
+				auditWhitespaceRootArgumentConstant,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testInstance.Run(testCase.name, func(subTest *testing.T) {
+			subTest.Parallel()
+
+			builder := audit.CommandBuilder{
+				LoggerProvider:        func() *zap.Logger { return zap.NewNop() },
+				ConfigurationProvider: func() audit.CommandConfiguration { return testCase.configuration },
+			}
+
+			command, buildError := builder.Build()
+			require.NoError(subTest, buildError)
+
+			command.SetContext(context.Background())
+			command.SetArgs(testCase.arguments)
+
+			outputBuffer := &strings.Builder{}
+			command.SetOut(outputBuffer)
+			command.SetErr(outputBuffer)
+
+			executionError := command.Execute()
+			require.Error(subTest, executionError)
+			require.Equal(subTest, auditMissingRootsErrorMessageConstant, executionError.Error())
+			require.Contains(subTest, outputBuffer.String(), command.UseLine())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- tolerate missing operation configuration for the invoked command by logging instead of failing initialization
- update CLI initialization tests to cover absent command-specific defaults
- add audit command coverage to ensure missing roots still trigger the existing help text

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8756fe26c8327b38b96b358b1f2f9