### PR TITLE
Expand tilde-prefixed repository roots across CLI commands

### DIFF
--- a/cmd/cli/repos/helpers.go
+++ b/cmd/cli/repos/helpers.go
@@ -9,11 +9,14 @@ import (
 
 	"github.com/temirov/git_scripts/internal/repos/prompt"
 	"github.com/temirov/git_scripts/internal/repos/shared"
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
 )
 
 const (
 	missingRepositoryRootsErrorMessageConstant = "no repository roots provided; specify --root or configure defaults"
 )
+
+var repositoryHomeDirectoryExpander = pathutils.NewHomeExpander()
 
 // LoggerProvider yields a zap logger for command execution.
 type LoggerProvider func() *zap.Logger
@@ -55,7 +58,8 @@ func trimRoots(raw []string) []string {
 		if len(candidate) == 0 {
 			continue
 		}
-		trimmed = append(trimmed, candidate)
+		expanded := repositoryHomeDirectoryExpander.Expand(candidate)
+		trimmed = append(trimmed, expanded)
 	}
 	return trimmed
 }


### PR DESCRIPTION
## Summary
- expand repository root sanitization to resolve user home shortcuts via a shared HomeExpander
- update repository command configuration sanitizers and tests to cover absolute, relative, and tilde-prefixed roots
- add an integration test covering a tilde-prefixed root passed on the command line

## Testing
- go test ./... *(fails: CLI integration log-format expectation because the repo config defaults to console logging)*

------
https://chatgpt.com/codex/tasks/task_e_68d8819d37148327b44f9985bf27985e