### PR TITLE
Refactor: centralize repository path sanitization

### DIFF
--- a/cmd/cli/repos/configuration.go
+++ b/cmd/cli/repos/configuration.go
@@ -60,14 +60,14 @@ func DefaultToolsConfiguration() ToolsConfiguration {
 // sanitize normalizes repository configuration values.
 func (configuration RemotesConfiguration) sanitize() RemotesConfiguration {
 	sanitized := configuration
-	sanitized.RepositoryRoots = trimRoots(configuration.RepositoryRoots)
+	sanitized.RepositoryRoots = repositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
 	return sanitized
 }
 
 // sanitize normalizes protocol configuration values.
 func (configuration ProtocolConfiguration) sanitize() ProtocolConfiguration {
 	sanitized := configuration
-	sanitized.RepositoryRoots = trimRoots(configuration.RepositoryRoots)
+	sanitized.RepositoryRoots = repositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
 	sanitized.FromProtocol = strings.TrimSpace(configuration.FromProtocol)
 	sanitized.ToProtocol = strings.TrimSpace(configuration.ToProtocol)
 	return sanitized
@@ -76,6 +76,6 @@ func (configuration ProtocolConfiguration) sanitize() ProtocolConfiguration {
 // sanitize normalizes rename configuration values.
 func (configuration RenameConfiguration) sanitize() RenameConfiguration {
 	sanitized := configuration
-	sanitized.RepositoryRoots = trimRoots(configuration.RepositoryRoots)
+	sanitized.RepositoryRoots = repositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
 	return sanitized
 }

--- a/cmd/cli/workflow/configuration.go
+++ b/cmd/cli/workflow/configuration.go
@@ -1,12 +1,10 @@
 package workflow
 
 import (
-	"strings"
-
 	pathutils "github.com/temirov/git_scripts/internal/utils/path"
 )
 
-var workflowConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
+var workflowConfigurationRepositoryPathSanitizer = pathutils.NewRepositoryPathSanitizer()
 
 // CommandConfiguration captures configuration values for workflow.
 type CommandConfiguration struct {
@@ -26,19 +24,6 @@ func DefaultCommandConfiguration() CommandConfiguration {
 // Sanitize normalizes configuration values.
 func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
-	sanitized.Roots = sanitizeRoots(configuration.Roots)
+	sanitized.Roots = workflowConfigurationRepositoryPathSanitizer.Sanitize(configuration.Roots)
 	return sanitized
-}
-
-func sanitizeRoots(raw []string) []string {
-	trimmed := make([]string, 0, len(raw))
-	for _, rawRoot := range raw {
-		trimmedRoot := strings.TrimSpace(rawRoot)
-		if len(trimmedRoot) == 0 {
-			continue
-		}
-		expandedRoot := workflowConfigurationHomeDirectoryExpander.Expand(trimmedRoot)
-		trimmed = append(trimmed, expandedRoot)
-	}
-	return trimmed
 }

--- a/cmd/cli/workflow/helpers.go
+++ b/cmd/cli/workflow/helpers.go
@@ -17,18 +17,18 @@ type PrompterFactory func(*cobra.Command) shared.ConfirmationPrompter
 // DetermineRoots selects the effective repository roots from flags and configuration.
 func DetermineRoots(flagValues []string, configured []string, preferFlag bool) []string {
 	if preferFlag {
-		trimmed := sanitizeRoots(flagValues)
+		trimmed := workflowConfigurationRepositoryPathSanitizer.Sanitize(flagValues)
 		if len(trimmed) > 0 {
 			return trimmed
 		}
 	}
 
-	configuredRoots := sanitizeRoots(configured)
+	configuredRoots := workflowConfigurationRepositoryPathSanitizer.Sanitize(configured)
 	if len(configuredRoots) > 0 {
 		return configuredRoots
 	}
 
-	trimmedFlagRoots := sanitizeRoots(flagValues)
+	trimmedFlagRoots := workflowConfigurationRepositoryPathSanitizer.Sanitize(flagValues)
 	if len(trimmedFlagRoots) > 0 {
 		return trimmedFlagRoots
 	}

--- a/internal/audit/command.go
+++ b/internal/audit/command.go
@@ -79,7 +79,7 @@ func (builder *CommandBuilder) parseOptions(command *cobra.Command) (CommandOpti
 	roots := append([]string{}, configuration.Roots...)
 	if command != nil && command.Flags().Changed(flagRootNameConstant) {
 		flagRoots, _ := command.Flags().GetStringSlice(flagRootNameConstant)
-		roots = sanitizeRoots(flagRoots)
+		roots = auditConfigurationRepositoryPathSanitizer.Sanitize(flagRoots)
 	}
 
 	if len(roots) == 0 {

--- a/internal/audit/command_test.go
+++ b/internal/audit/command_test.go
@@ -2,6 +2,8 @@ package audit_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,6 +11,8 @@ import (
 	"go.uber.org/zap"
 
 	audit "github.com/temirov/git_scripts/internal/audit"
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
 )
 
 const (
@@ -17,6 +21,7 @@ const (
 	auditRootFlagNameConstant             = "--root"
 	auditConfigurationMissingSubtestName  = "configuration_and_flags_missing"
 	auditWhitespaceRootFlagSubtestName    = "flag_provided_without_roots"
+	auditTildeRootArgumentConstant        = "~/audit/repositories"
 )
 
 func TestCommandBuilderDisplaysHelpWhenRootsMissing(testInstance *testing.T) {
@@ -68,4 +73,82 @@ func TestCommandBuilderDisplaysHelpWhenRootsMissing(testInstance *testing.T) {
 			require.Contains(subTest, outputBuffer.String(), command.UseLine())
 		})
 	}
+}
+
+func TestCommandBuilderExpandsTildeRoots(testInstance *testing.T) {
+	testInstance.Helper()
+
+	homeDirectory, homeDirectoryError := os.UserHomeDir()
+	require.NoError(testInstance, homeDirectoryError)
+
+	expectedRoot := filepath.Join(homeDirectory, "audit", "repositories")
+
+	repositoryDiscoverer := &repositoryDiscovererStub{}
+	builder := audit.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		Discoverer:     repositoryDiscoverer,
+		GitExecutor:    &gitExecutorStub{},
+		GitManager:     &gitRepositoryManagerStub{},
+		GitHubResolver: &gitHubResolverStub{},
+		ConfigurationProvider: func() audit.CommandConfiguration {
+			return audit.CommandConfiguration{}
+		},
+	}
+
+	command, buildError := builder.Build()
+	require.NoError(testInstance, buildError)
+
+	command.SetContext(context.Background())
+	command.SetArgs([]string{auditRootFlagNameConstant, auditTildeRootArgumentConstant})
+
+	outputBuffer := &strings.Builder{}
+	command.SetOut(outputBuffer)
+	command.SetErr(outputBuffer)
+
+	executionError := command.Execute()
+	require.NoError(testInstance, executionError)
+	require.Equal(testInstance, []string{expectedRoot}, repositoryDiscoverer.receivedRoots)
+}
+
+type repositoryDiscovererStub struct {
+	receivedRoots []string
+}
+
+func (stub *repositoryDiscovererStub) DiscoverRepositories(roots []string) ([]string, error) {
+	stub.receivedRoots = append([]string{}, roots...)
+	return []string{}, nil
+}
+
+type gitExecutorStub struct{}
+
+func (stub *gitExecutorStub) ExecuteGit(ctx context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{}, nil
+}
+
+func (stub *gitExecutorStub) ExecuteGitHubCLI(ctx context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{}, nil
+}
+
+type gitRepositoryManagerStub struct{}
+
+func (stub *gitRepositoryManagerStub) CheckCleanWorktree(ctx context.Context, repositoryPath string) (bool, error) {
+	return true, nil
+}
+
+func (stub *gitRepositoryManagerStub) GetCurrentBranch(ctx context.Context, repositoryPath string) (string, error) {
+	return "main", nil
+}
+
+func (stub *gitRepositoryManagerStub) GetRemoteURL(ctx context.Context, repositoryPath string, remoteName string) (string, error) {
+	return "https://github.com/example/repo.git", nil
+}
+
+func (stub *gitRepositoryManagerStub) SetRemoteURL(ctx context.Context, repositoryPath string, remoteName string, remoteURL string) error {
+	return nil
+}
+
+type gitHubResolverStub struct{}
+
+func (stub *gitHubResolverStub) ResolveRepoMetadata(ctx context.Context, repository string) (githubcli.RepositoryMetadata, error) {
+	return githubcli.RepositoryMetadata{}, nil
 }

--- a/internal/audit/configuration.go
+++ b/internal/audit/configuration.go
@@ -1,12 +1,10 @@
 package audit
 
 import (
-	"strings"
-
 	pathutils "github.com/temirov/git_scripts/internal/utils/path"
 )
 
-var auditConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
+var auditConfigurationRepositoryPathSanitizer = pathutils.NewRepositoryPathSanitizer()
 
 // CommandConfiguration captures persistent settings for the audit command.
 type CommandConfiguration struct {
@@ -26,20 +24,7 @@ func DefaultCommandConfiguration() CommandConfiguration {
 func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
 
-	sanitized.Roots = sanitizeRoots(configuration.Roots)
+	sanitized.Roots = auditConfigurationRepositoryPathSanitizer.Sanitize(configuration.Roots)
 
-	return sanitized
-}
-
-func sanitizeRoots(raw []string) []string {
-	sanitized := make([]string, 0, len(raw))
-	for rawRootIndex := range raw {
-		trimmed := strings.TrimSpace(raw[rawRootIndex])
-		if len(trimmed) == 0 {
-			continue
-		}
-		expandedRoot := auditConfigurationHomeDirectoryExpander.Expand(trimmed)
-		sanitized = append(sanitized, expandedRoot)
-	}
 	return sanitized
 }

--- a/internal/branches/command.go
+++ b/internal/branches/command.go
@@ -217,20 +217,12 @@ func (builder *CommandBuilder) resolveRepositoryDiscoverer() RepositoryDiscovere
 }
 
 func (builder *CommandBuilder) determineRepositoryRoots(arguments []string, configuredRoots []string) []string {
-	repositoryRoots := make([]string, 0, len(arguments))
-	for argumentIndex := range arguments {
-		trimmedRoot := strings.TrimSpace(arguments[argumentIndex])
-		if len(trimmedRoot) == 0 {
-			continue
-		}
-		repositoryRoots = append(repositoryRoots, trimmedRoot)
+	sanitizedArgumentRoots := branchConfigurationRepositoryPathSanitizer.Sanitize(arguments)
+	if len(sanitizedArgumentRoots) > 0 {
+		return sanitizedArgumentRoots
 	}
 
-	if len(repositoryRoots) > 0 {
-		return repositoryRoots
-	}
-
-	sanitizedConfiguredRoots := sanitizeRoots(configuredRoots)
+	sanitizedConfiguredRoots := branchConfigurationRepositoryPathSanitizer.Sanitize(configuredRoots)
 	if len(sanitizedConfiguredRoots) > 0 {
 		return sanitizedConfiguredRoots
 	}

--- a/internal/branches/configuration.go
+++ b/internal/branches/configuration.go
@@ -6,7 +6,7 @@ import (
 	pathutils "github.com/temirov/git_scripts/internal/utils/path"
 )
 
-var branchConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
+var branchConfigurationRepositoryPathSanitizer = pathutils.NewRepositoryPathSanitizer()
 
 // CommandConfiguration captures configuration values for the branch cleanup command.
 type CommandConfiguration struct {
@@ -31,20 +31,7 @@ func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
 
 	sanitized.RemoteName = strings.TrimSpace(configuration.RemoteName)
-	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
+	sanitized.RepositoryRoots = branchConfigurationRepositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
 
-	return sanitized
-}
-
-func sanitizeRoots(raw []string) []string {
-	sanitized := make([]string, 0, len(raw))
-	for _, rootCandidate := range raw {
-		trimmed := strings.TrimSpace(rootCandidate)
-		if len(trimmed) == 0 {
-			continue
-		}
-		expandedRoot := branchConfigurationHomeDirectoryExpander.Expand(trimmed)
-		sanitized = append(sanitized, expandedRoot)
-	}
 	return sanitized
 }

--- a/internal/migrate/command.go
+++ b/internal/migrate/command.go
@@ -211,12 +211,12 @@ func (builder *CommandBuilder) parseOptions(command *cobra.Command, arguments []
 }
 
 func (builder *CommandBuilder) determineRepositoryRoots(arguments []string, configuredRoots []string) []string {
-	argumentRoots := sanitizeRoots(arguments)
+	argumentRoots := migrateConfigurationRepositoryPathSanitizer.Sanitize(arguments)
 	if len(argumentRoots) > 0 {
 		return argumentRoots
 	}
 
-	sanitizedConfiguredRoots := sanitizeRoots(configuredRoots)
+	sanitizedConfiguredRoots := migrateConfigurationRepositoryPathSanitizer.Sanitize(configuredRoots)
 	if len(sanitizedConfiguredRoots) > 0 {
 		return sanitizedConfiguredRoots
 	}

--- a/internal/migrate/configuration.go
+++ b/internal/migrate/configuration.go
@@ -1,12 +1,10 @@
 package migrate
 
 import (
-	"strings"
-
 	pathutils "github.com/temirov/git_scripts/internal/utils/path"
 )
 
-var migrateConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
+var migrateConfigurationRepositoryPathSanitizer = pathutils.NewRepositoryPathSanitizer()
 
 // CommandConfiguration captures persisted configuration for branch migration.
 type CommandConfiguration struct {
@@ -25,19 +23,6 @@ func DefaultCommandConfiguration() CommandConfiguration {
 // Sanitize trims configured values and removes empty entries.
 func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
-	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
-	return sanitized
-}
-
-func sanitizeRoots(raw []string) []string {
-	sanitized := make([]string, 0, len(raw))
-	for _, candidateRoot := range raw {
-		trimmed := strings.TrimSpace(candidateRoot)
-		if len(trimmed) == 0 {
-			continue
-		}
-		expandedRoot := migrateConfigurationHomeDirectoryExpander.Expand(trimmed)
-		sanitized = append(sanitized, expandedRoot)
-	}
+	sanitized.RepositoryRoots = migrateConfigurationRepositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
 	return sanitized
 }

--- a/internal/packages/command.go
+++ b/internal/packages/command.go
@@ -283,7 +283,7 @@ func (builder *CommandBuilder) determineRepositoryRoots(command *cobra.Command, 
 			return nil, flagError
 		}
 
-		sanitizedFlagRoots := sanitizeRoots(flagRoots)
+		sanitizedFlagRoots := packagesConfigurationRepositoryPathSanitizer.Sanitize(flagRoots)
 		if len(sanitizedFlagRoots) > 0 {
 			return sanitizedFlagRoots, nil
 		}

--- a/internal/packages/configuration.go
+++ b/internal/packages/configuration.go
@@ -1,12 +1,10 @@
 package packages
 
 import (
-	"strings"
-
 	pathutils "github.com/temirov/git_scripts/internal/utils/path"
 )
 
-var packagesConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
+var packagesConfigurationRepositoryPathSanitizer = pathutils.NewRepositoryPathSanitizer()
 
 const (
 	defaultTokenSourceValueConstant = "env:GITHUB_PACKAGES_TOKEN"
@@ -41,22 +39,6 @@ func (configuration Configuration) Sanitize() Configuration {
 // Sanitize trims purge configuration values and removes empty entries.
 func (configuration PurgeConfiguration) Sanitize() PurgeConfiguration {
 	sanitized := configuration
-	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
+	sanitized.RepositoryRoots = packagesConfigurationRepositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
 	return sanitized
-}
-
-func sanitizeRoots(candidateRoots []string) []string {
-	sanitizedRoots := make([]string, 0, len(candidateRoots))
-	for _, rootCandidate := range candidateRoots {
-		trimmedRoot := strings.TrimSpace(rootCandidate)
-		if len(trimmedRoot) == 0 {
-			continue
-		}
-		expandedRoot := packagesConfigurationHomeDirectoryExpander.Expand(trimmedRoot)
-		sanitizedRoots = append(sanitizedRoots, expandedRoot)
-	}
-	if len(sanitizedRoots) == 0 {
-		return nil
-	}
-	return sanitizedRoots
 }

--- a/internal/utils/path/repository_path_sanitizer.go
+++ b/internal/utils/path/repository_path_sanitizer.go
@@ -1,0 +1,79 @@
+package pathutils
+
+import "strings"
+
+const (
+	booleanLiteralTrueValueConstant  = "true"
+	booleanLiteralFalseValueConstant = "false"
+)
+
+// RepositoryPathSanitizerConfiguration controls repository path sanitization behavior.
+type RepositoryPathSanitizerConfiguration struct {
+	// ExcludeBooleanLiteralCandidates removes arguments that represent boolean literals.
+	ExcludeBooleanLiteralCandidates bool
+}
+
+// RepositoryPathSanitizer normalizes repository path inputs consistently across commands.
+type RepositoryPathSanitizer struct {
+	homeExpander  *HomeExpander
+	configuration RepositoryPathSanitizerConfiguration
+}
+
+// NewRepositoryPathSanitizer constructs a RepositoryPathSanitizer with default behavior.
+func NewRepositoryPathSanitizer() *RepositoryPathSanitizer {
+	return NewRepositoryPathSanitizerWithConfiguration(nil, RepositoryPathSanitizerConfiguration{})
+}
+
+// NewRepositoryPathSanitizerWithConfiguration constructs a RepositoryPathSanitizer using the provided expander and configuration.
+func NewRepositoryPathSanitizerWithConfiguration(homeExpander *HomeExpander, configuration RepositoryPathSanitizerConfiguration) *RepositoryPathSanitizer {
+	resolvedExpander := homeExpander
+	if resolvedExpander == nil {
+		resolvedExpander = NewHomeExpander()
+	}
+
+	return &RepositoryPathSanitizer{
+		homeExpander:  resolvedExpander,
+		configuration: configuration,
+	}
+}
+
+// Sanitize trims whitespace, expands the user's home directory, and removes disallowed values.
+func (sanitizer *RepositoryPathSanitizer) Sanitize(candidatePaths []string) []string {
+	if sanitizer == nil {
+		return sanitizePathsWithExpander(NewHomeExpander(), RepositoryPathSanitizerConfiguration{}, candidatePaths)
+	}
+
+	return sanitizePathsWithExpander(sanitizer.homeExpander, sanitizer.configuration, candidatePaths)
+}
+
+func sanitizePathsWithExpander(expander *HomeExpander, configuration RepositoryPathSanitizerConfiguration, candidatePaths []string) []string {
+	sanitizedPaths := make([]string, 0, len(candidatePaths))
+	for candidateIndex := range candidatePaths {
+		trimmedCandidate := strings.TrimSpace(candidatePaths[candidateIndex])
+		if len(trimmedCandidate) == 0 {
+			continue
+		}
+
+		if configuration.ExcludeBooleanLiteralCandidates && isBooleanLiteral(trimmedCandidate) {
+			continue
+		}
+
+		expandedPath := expander.Expand(trimmedCandidate)
+		if len(expandedPath) == 0 {
+			continue
+		}
+
+		sanitizedPaths = append(sanitizedPaths, expandedPath)
+	}
+
+	if len(sanitizedPaths) == 0 {
+		return nil
+	}
+
+	return sanitizedPaths
+}
+
+func isBooleanLiteral(candidate string) bool {
+	loweredCandidate := strings.ToLower(candidate)
+	return loweredCandidate == booleanLiteralTrueValueConstant || loweredCandidate == booleanLiteralFalseValueConstant
+}

--- a/internal/utils/path/repository_path_sanitizer_test.go
+++ b/internal/utils/path/repository_path_sanitizer_test.go
@@ -1,0 +1,81 @@
+package pathutils_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
+)
+
+const (
+	testCaseAbsolutePathSuffixConstant          = "repository-path-sanitizer"
+	testCaseTildeRelativePathConstant           = "Projects/example"
+	testCaseWhitespacePrefixConstant            = "  "
+	testCaseWhitespaceSuffixConstant            = "\t"
+	testCaseBooleanLiteralTrueUppercaseConstant = "TRUE"
+	testCaseBooleanLiteralFalseMixedConstant    = "False"
+	testCaseSanitizerDefaultCaseNameConstant    = "default_configuration"
+	testCaseBooleanFilterCaseNameConstant       = "boolean_filter_configuration"
+)
+
+func TestRepositoryPathSanitizerNormalizesInputs(testInstance *testing.T) {
+	testInstance.Helper()
+
+	homeDirectory, homeDirectoryError := os.UserHomeDir()
+	require.NoError(testInstance, homeDirectoryError)
+
+	temporaryDirectory := testInstance.TempDir()
+	absolutePath := filepath.Join(temporaryDirectory, testCaseAbsolutePathSuffixConstant)
+	tildeInput := filepath.Join("~", testCaseTildeRelativePathConstant)
+	expandedTilde := filepath.Join(homeDirectory, testCaseTildeRelativePathConstant)
+
+	testCases := []struct {
+		name            string
+		sanitizer       *pathutils.RepositoryPathSanitizer
+		inputs          []string
+		expectedOutputs []string
+	}{
+		{
+			name:      testCaseSanitizerDefaultCaseNameConstant,
+			sanitizer: pathutils.NewRepositoryPathSanitizer(),
+			inputs: []string{
+				"",
+				testCaseWhitespacePrefixConstant + absolutePath + testCaseWhitespaceSuffixConstant,
+				testCaseWhitespacePrefixConstant + tildeInput + testCaseWhitespaceSuffixConstant,
+			},
+			expectedOutputs: []string{absolutePath, expandedTilde},
+		},
+		{
+			name:      testCaseBooleanFilterCaseNameConstant,
+			sanitizer: pathutils.NewRepositoryPathSanitizerWithConfiguration(nil, pathutils.RepositoryPathSanitizerConfiguration{ExcludeBooleanLiteralCandidates: true}),
+			inputs: []string{
+				testCaseBooleanLiteralTrueUppercaseConstant,
+				testCaseBooleanLiteralFalseMixedConstant,
+				tildeInput,
+			},
+			expectedOutputs: []string{expandedTilde},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testInstance.Run(testCase.name, func(subTest *testing.T) {
+			subTest.Helper()
+
+			sanitized := testCase.sanitizer.Sanitize(testCase.inputs)
+			require.Equal(subTest, testCase.expectedOutputs, sanitized)
+		})
+	}
+}
+
+func TestRepositoryPathSanitizerReturnsNilForEmptyResults(testInstance *testing.T) {
+	testInstance.Helper()
+
+	sanitizer := pathutils.NewRepositoryPathSanitizer()
+
+	sanitized := sanitizer.Sanitize([]string{"   ", "\n"})
+	require.Nil(testInstance, sanitized)
+}


### PR DESCRIPTION
## Summary
- add a shared RepositoryPathSanitizer that trims, expands, and optionally filters boolean literal roots
- replace bespoke sanitize/trim helpers across CLI and internal packages to use the shared sanitizer
- extend command tests to cover tilde expansion and empty-root rejection via the common sanitizer

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8903a4a088327aa25b76717361da3